### PR TITLE
Fix feral attack power

### DIFF
--- a/libs/StatLogic-1.0/StatLogic-1.0.lua
+++ b/libs/StatLogic-1.0/StatLogic-1.0.lua
@@ -3149,7 +3149,7 @@ function StatLogic:GetAPPerAgi(class)
 		class = ClassNameToID[playerClass]
 	end
 	-- Check druid cat form
-	if (class == 9) and GetShapeshiftForm() == 2 then		-- ["Cat Form"]
+	if (class == 9) and GetShapeshiftForm() == 2 or GetShapeshiftForm() == 3 then		-- ["Cat Form"]
 		return 1
 	end
 	return APPerAgi[class], "AP"


### PR DESCRIPTION
Fixes #31 

The number for cat form is either 2 or 3 depending on if the druid has learned aquatic form or not.