### PR TITLE
Fix "Hit Chance" DE translation

### DIFF
--- a/locales/deDE.lua
+++ b/locales/deDE.lua
@@ -272,7 +272,7 @@ L["Sum Healing"] = "Heilung zusammenrechnen"
 L["Healing <- Healing Intellect, Spirit, Agility, Strength"] = "Heilung <- Heilung, Intelligenz, Willenskraft, Beweglichkeit, Sträke"
 -- /rb sum stat hit
 L["Sum Hit Chance"] = "Trefferchance zusammenrechnen"
-L["Hit Chance <- Hit Rating Weapon Skill Rating"] = "Trefferchance <- Trefferwertung, Waffenfertigkeitswertung"
+L["Hit Chance <- Hit Rating, Weapon Skill Rating"] = "Trefferchance <- Trefferwertung, Waffenfertigkeitswertung"
 -- /rb sum stat crit
 L["Sum Crit Chance"] = "kritische Trefferchance zusammenrechnen"
 L["Crit Chance <- Crit Rating Agility, Weapon Skill Rating"] = "kritische Trefferchance <- kritische Trefferwertung, Beweglichkeit, Waffenfertigkeitswertung"


### PR DESCRIPTION
Fix original English string (missing ",") to let the addon correctly translate it into German.