### PR TITLE
Update frFR.lua

### DIFF
--- a/libs/StatLogic-1.0/frFR.lua
+++ b/libs/StatLogic-1.0/frFR.lua
@@ -155,6 +155,7 @@ L["PreScanPatterns"] = {
 	["^Équipé\194\160: Rend (%d+) points de mana toutes les 5 seco?n?d?e?s?%.?$"]= "MANA_REG",
 	["Renforcé %(%+(%d+) Armure%)"]= "ARMOR_BONUS",
 	["Lunette %(%+(%d+) points? de dégâts?%)"]="RANGED_AP",
+	["^Dégâts : %+?%d+ %- (%d+)$"] = "MAX_DAMAGE",
 	["^%(([%d%,]+) dégâts par seconde%)$"] = "DPS",
 
 	-- Exclude
@@ -186,7 +187,7 @@ L["DeepScanSeparators"] = {
 	"/", -- "+10 Defense Rating/+10 Stamina/+15 Block Value": ZG Enchant
 	" & ", -- "+26 Healing Spells & 2% Reduced Threat": Bracing Earthstorm Diamond ID:25897
 	", ", -- "+6 Spell Damage, +5 Spell Crit Rating": Potent Ornate Topaz ID: 28123
-	"%. ", -- "Equip: Increases attack power by 81 when fighting Undead. It also allows the acquisition of Scourgestones on behalf of the Argent Dawn.": Seal of the Dawn
+	"%. ", -- "Equip: Increases attack power by 81 when fighting Mort-vivant. It also allows the acquisition of Scourgestones on behalf of the Argent Dawn.": Seal of the Dawn
 }
 L["DeepScanWordSeparators"] = {
 	" et ", -- "Critical Rating +6 and Dodge Rating +5": Assassin's Fire Opal ID:30565
@@ -272,8 +273,8 @@ L["StatIDLookup"] = {
 
 	--ToDo
 	["Augmente dela puissance d'attaque lorsque vous combattez des morts-vivants"] = {"AP_UNDEAD",},
-	--["Increases attack powerwhen fighting Undead"] = {"AP_UNDEAD",},
-	--["Increases attack powerwhen fighting Undead.  It also allows the acquisition of Scourgestones on behalf of the Argent Dawn"] = {"AP_UNDEAD",},
+	--["Increases attack powerwhen fighting Mort-vivant"] = {"AP_UNDEAD",},
+	--["Increases attack powerwhen fighting Mort-vivant.  It also allows the acquisition of Scourgestones on behalf of the Argent Dawn"] = {"AP_UNDEAD",},
 	--["Increases attack powerwhen fighting Demons"] = {"AP_DEMON",},
 	--["Attack Power in Cat, Bear, and Dire Bear forms only"] = {"FERAL_AP",},
 	--["Increases attack powerin Cat, Bear, Dire Bear, and Moonkin forms only"] = {"FERAL_AP",},
@@ -437,7 +438,7 @@ L["StatIDLookup"] = {
 	["le score de la compétence armes de pugilat"] = {"FIST_WEAPON_RATING"},
 	["le score de compétence combat farouche"] = {"FERAL_WEAPON_RATING"},
 	["le score de la compétence mains nues"] = {"FIST_WEAPON_RATING"},
-
+	["le score d’expertise"] = {"EXPERTISE_RATING"},
 	--ToDo
 	--["Increases gun skill rating"] = {"GUN_WEAPON_RATING"},
 	--["Increases Crossbow skill rating"] = {"CROSSBOW_WEAPON_RATING"},
@@ -465,98 +466,100 @@ D["StatIDToName"] = {
 	--[StatID] = {FullName, ShortName},
 	---------------------------------------------------------------------------
 	-- Tier1 Stats - Stats parsed directly off items
-	["EMPTY_SOCKET_RED"] = {EMPTY_SOCKET_RED, EMPTY_SOCKET_RED}, -- EMPTY_SOCKET_RED = "Red Socket";
-	["EMPTY_SOCKET_YELLOW"] = {EMPTY_SOCKET_YELLOW, EMPTY_SOCKET_YELLOW}, -- EMPTY_SOCKET_YELLOW = "Yellow Socket";
-	["EMPTY_SOCKET_BLUE"] = {EMPTY_SOCKET_BLUE, EMPTY_SOCKET_BLUE}, -- EMPTY_SOCKET_BLUE = "Blue Socket";
-	["EMPTY_SOCKET_META"] = {EMPTY_SOCKET_META, EMPTY_SOCKET_META}, -- EMPTY_SOCKET_META = "Meta Socket";
+	["EMPTY_SOCKET_RED"] = {"Châsse rouge", "Châsse rouge"},
+	["EMPTY_SOCKET_YELLOW"] = {"Châsse jaune", "Châsse jaune"},
+	["EMPTY_SOCKET_BLUE"] = {"Châsse bleue", "Châsse bleue"},
+	["EMPTY_SOCKET_META"] = {"Méta-châsse", "Méta-châsse"},
 
-	["IGNORE_ARMOR"] = {"Ignore Armor", "Ignore Armor"},
-	["STEALTH_LEVEL"] = {"Stealth Level", "Stealth"},
-	["MELEE_DMG"] = {"Melee Weapon "..DAMAGE, "Wpn Dmg"}, -- DAMAGE = "Damage"
-	["MOUNT_SPEED"] = {"Mount Speed(%)", "Mount Spd(%)"},
-	["RUN_SPEED"] = {"Run Speed(%)", "Run Spd(%)"},
+	["IGNORE_ARMOR"] = {"Armure ignorée", "Armure ignorée"},
+	["STEALTH_LEVEL"] = {"Niveau de camouflage", "Camouflage"},
+	["MELEE_DMG"] = {"Dégâts de l'arme", "Dégâts Arme"},
+	["MOUNT_SPEED"] = {"Vitesse de monte (%)", "Vit. de monte (%)"},
+	["RUN_SPEED"] = {"Vitesse (%)","Vit. (%)"},
 
-	["STR"] = {SPELL_STAT1_NAME, "Str"},
-	["AGI"] = {SPELL_STAT2_NAME, "Agi"},
-	["STA"] = {SPELL_STAT3_NAME, "Sta"},
-	["INT"] = {SPELL_STAT4_NAME, "Int"},
-	["SPI"] = {SPELL_STAT5_NAME, "Spi"},
-	["ARMOR"] = {ARMOR, ARMOR},
-	["ARMOR_BONUS"] = {ARMOR.." from bonus", ARMOR.."(Bonus)"},
+	["STR"] = {"Force", "For"},
+	["AGI"] = {"Agilité", "Agi"},
+	["STA"] = {"Endurance", "End"},
+	["INT"] = {"Intelligence", "Int"},
+	["SPI"] = {"Esprit", "Esp"},
+	["ARMOR"] = {"Armure", "Armure"},
+	["ARMOR_BONUS"] = {"Armure bonus", "Armure bonus"},
 
-	["FIRE_RES"] = {RESISTANCE2_NAME, "FR"},
-	["NATURE_RES"] = {RESISTANCE3_NAME, "NR"},
-	["FROST_RES"] = {RESISTANCE4_NAME, "FrR"},
-	["SHADOW_RES"] = {RESISTANCE5_NAME, "SR"},
-	["ARCANE_RES"] = {RESISTANCE6_NAME, "AR"},
+	["FIRE_RES"] = {"Résistance au Feu", "RF"},
+	["NATURE_RES"] = {"Résistance à la Nature", "RN"},
+	["FROST_RES"] = {"Résistance au Givre", "RG"},
+	["SHADOW_RES"] = {"Résistance à l'Ombre", "RO"},
+	["ARCANE_RES"] = {"Résistance aux Arcanes", "RA"},
 
-	["FISHING"] = {"Fishing", "Fishing"},
-	["MINING"] = {"Mining", "Mining"},
-	["HERBALISM"] = {"Herbalism", "Herbalism"},
-	["SKINNING"] = {"Skinning", "Skinning"},
+	["FISHING"] = {"Pêche", "Pêche"},
+	["MINING"] = {"Minage", "Minage"},
+	["HERBALISM"] = {"Herboristerie", "Herboristerie"},
+	["SKINNING"] = {"Dépeçage", "Dépeçage"},
 
-	["BLOCK_VALUE"] = {"Block Value", "Block Value"},
+	["BLOCK_VALUE"] = {"Valeur de blocage", "Valeur de blocage"},
 
-	["AP"] = {ATTACK_POWER_TOOLTIP, "AP"},
-	["RANGED_AP"] = {RANGED_ATTACK_POWER, "RAP"},
-	["FERAL_AP"] = {"Feral "..ATTACK_POWER_TOOLTIP, "Feral AP"},
-	["AP_UNDEAD"] = {ATTACK_POWER_TOOLTIP.." (Undead)", "AP(Undead)"},
-	["AP_DEMON"] = {ATTACK_POWER_TOOLTIP.." (Demon)", "AP(Demon)"},
+	["AP"] = {"Puissance d'attaque", "PA"},
+	["RANGED_AP"] = {"Puissance d'attaque à distance", "PA Dist."},
+	["FERAL_AP"] = {"Puissance d'attaque Farouche", "PA Farouche"},
+	["AP_UNDEAD"] = {"Puissance d'attaque (Mort-vivant)", "PA (Mort-vivant)"},
+	["AP_DEMON"] = {"Puissance d'attaque (Démon)", "PA (Démon)"},
 
-	["HEAL"] = {"Healing", "Heal"},
+	["HEAL"] = {"Puissance des soins", "Soins"},
 
-	["SPELL_DMG"] = {PLAYERSTAT_SPELL_COMBAT.." "..DAMAGE, PLAYERSTAT_SPELL_COMBAT.." Dmg"},
-	["SPELL_DMG_UNDEAD"] = {PLAYERSTAT_SPELL_COMBAT.." "..DAMAGE.." (Undead)", PLAYERSTAT_SPELL_COMBAT.." Dmg".."(Undead)"},
-	["SPELL_DMG_DEMON"] = {PLAYERSTAT_SPELL_COMBAT.." "..DAMAGE.." (Demon)", PLAYERSTAT_SPELL_COMBAT.." Dmg".."(Demon)"},
-	["HOLY_SPELL_DMG"] = {SPELL_SCHOOL1_CAP.." "..DAMAGE, SPELL_SCHOOL1_CAP.." Dmg"},
-	["FIRE_SPELL_DMG"] = {SPELL_SCHOOL2_CAP.." "..DAMAGE, SPELL_SCHOOL2_CAP.." Dmg"},
-	["NATURE_SPELL_DMG"] = {SPELL_SCHOOL3_CAP.." "..DAMAGE, SPELL_SCHOOL3_CAP.." Dmg"},
-	["FROST_SPELL_DMG"] = {SPELL_SCHOOL4_CAP.." "..DAMAGE, SPELL_SCHOOL4_CAP.." Dmg"},
-	["SHADOW_SPELL_DMG"] = {SPELL_SCHOOL5_CAP.." "..DAMAGE, SPELL_SCHOOL5_CAP.." Dmg"},
-	["ARCANE_SPELL_DMG"] = {SPELL_SCHOOL6_CAP.." "..DAMAGE, SPELL_SCHOOL6_CAP.." Dmg"},
+	["SPELL_DMG"] = {"Dégâts des sorts", "Dégâts"},
+	["SPELL_DMG_UNDEAD"] = {"Dégâts des sorts (Mort-vivant)", "Dégâts (Mort-vivant)"},
+	["SPELL_DMG_DEMON"] = {"Dégâts des sorts (Démon)", "Dégâts (Démon)"},
+	["HOLY_SPELL_DMG"] = {"Dégâts des sorts du Sacré","Dégâts Sacré"},
+	["FIRE_SPELL_DMG"] = {"Dégâts des sorts de Feu","Dégâts Feu"},
+	["NATURE_SPELL_DMG"] = {"Dégâts des sorts de Nature","Dégâts Nature"},
+	["FROST_SPELL_DMG"] = {"Dégâts des sorts de Givre","Dégâts Givre"},
+	["SHADOW_SPELL_DMG"] = {"Dégâts des sorts d'Ombre","Dégâts Ombre"},
+	["ARCANE_SPELL_DMG"] = {"Dégâts des sorts des Arcanes","Dégâts Arcanes"},
 
-	["SPELLPEN"] = {PLAYERSTAT_SPELL_COMBAT.." "..SPELL_PENETRATION, SPELL_PENETRATION},
+	["SPELLPEN"] = {"Pénétration des sorts", "Pénétration"},
 
-	["HEALTH"] = {HEALTH, HP},
-	["MANA"] = {MANA, MP},
-	["HEALTH_REG"] = {HEALTH.." Regen", "HP5"},
-	["MANA_REG"] = {MANA.." Regen", "MP5"},
+	["HEALTH"] = {"Points de vie", "PV"},
+	["MANA"] = {"Points de mana", "Mana"},
+	["HEALTH_REG"] = {"Régén. vie", "Hp5"},
+	["MANA_REG"] = {"Régén. mana", "Mp5"},
 
-	["MAX_DAMAGE"] = {"Max Damage", "Max Dmg"},
-	["DPS"] = {"Dégats par seconde", "DPS"},
+	["MAX_DAMAGE"] = {"Dégâts maximum", "Dégâts Max"},
+	["DPS"] = {"Dégâts par seconde", "DPS"},
 
-	["DEFENSE_RATING"] = {COMBAT_RATING_NAME2, COMBAT_RATING_NAME2}, -- COMBAT_RATING_NAME2 = "Defense Rating"
-	["DODGE_RATING"] = {COMBAT_RATING_NAME3, COMBAT_RATING_NAME3}, -- COMBAT_RATING_NAME3 = "Dodge Rating"
-	["PARRY_RATING"] = {COMBAT_RATING_NAME4, COMBAT_RATING_NAME4}, -- COMBAT_RATING_NAME4 = "Parry Rating"
-	["BLOCK_RATING"] = {COMBAT_RATING_NAME5, COMBAT_RATING_NAME5}, -- COMBAT_RATING_NAME5 = "Block Rating"
-	["MELEE_HIT_RATING"] = {COMBAT_RATING_NAME6, COMBAT_RATING_NAME6}, -- COMBAT_RATING_NAME6 = "Hit Rating"
-	["RANGED_HIT_RATING"] = {PLAYERSTAT_RANGED_COMBAT.." "..COMBAT_RATING_NAME6, PLAYERSTAT_RANGED_COMBAT.." "..COMBAT_RATING_NAME6}, -- PLAYERSTAT_RANGED_COMBAT = "Ranged"
-	["SPELL_HIT_RATING"] = {PLAYERSTAT_SPELL_COMBAT.." "..COMBAT_RATING_NAME6, PLAYERSTAT_SPELL_COMBAT.." "..COMBAT_RATING_NAME6}, -- PLAYERSTAT_SPELL_COMBAT = "Spell"
-	["MELEE_HIT_AVOID_RATING"] = {"Hit Avoidance "..RATING, "Hit Avoidance "..RATING},
-	["RANGED_HIT_AVOID_RATING"] = {PLAYERSTAT_RANGED_COMBAT.." Hit Avoidance "..RATING, PLAYERSTAT_RANGED_COMBAT.." Hit Avoidance "..RATING},
-	["SPELL_HIT_AVOID_RATING"] = {PLAYERSTAT_SPELL_COMBAT.." Hit Avoidance "..RATING, PLAYERSTAT_SPELL_COMBAT.." Hit Avoidance "..RATING},
-	["MELEE_CRIT_RATING"] = {COMBAT_RATING_NAME9, COMBAT_RATING_NAME9}, -- COMBAT_RATING_NAME9 = "Crit Rating"
-	["RANGED_CRIT_RATING"] = {PLAYERSTAT_RANGED_COMBAT.." "..COMBAT_RATING_NAME9, PLAYERSTAT_RANGED_COMBAT.." "..COMBAT_RATING_NAME9},
-	["SPELL_CRIT_RATING"] = {PLAYERSTAT_SPELL_COMBAT.." "..COMBAT_RATING_NAME9, PLAYERSTAT_SPELL_COMBAT.." "..COMBAT_RATING_NAME9},
-	["MELEE_CRIT_AVOID_RATING"] = {"Crit Avoidance "..RATING, "Crit Avoidance "..RATING},
-	["RANGED_CRIT_AVOID_RATING"] = {PLAYERSTAT_RANGED_COMBAT.." Crit Avoidance "..RATING, PLAYERSTAT_RANGED_COMBAT.." Crit Avoidance "..RATING},
-	["SPELL_CRIT_AVOID_RATING"] = {PLAYERSTAT_SPELL_COMBAT.." Crit Avoidance "..RATING, PLAYERSTAT_SPELL_COMBAT.." Crit Avoidance "..RATING},
-	["RESILIENCE_RATING"] = {COMBAT_RATING_NAME15, COMBAT_RATING_NAME15}, -- COMBAT_RATING_NAME15 = "Resilience"
-	["MELEE_HASTE_RATING"] = {"Haste "..RATING, "Haste "..RATING}, --
-	["RANGED_HASTE_RATING"] = {PLAYERSTAT_RANGED_COMBAT.." Haste "..RATING, PLAYERSTAT_RANGED_COMBAT.." Haste "..RATING},
-	["SPELL_HASTE_RATING"] = {PLAYERSTAT_SPELL_COMBAT.." Haste "..RATING, PLAYERSTAT_SPELL_COMBAT.." Haste "..RATING},
-	["DAGGER_WEAPON_RATING"] = {"Dagger "..SKILL.." "..RATING, "Dagger "..RATING}, -- SKILL = "Skill"
-	["SWORD_WEAPON_RATING"] = {"Sword "..SKILL.." "..RATING, "Sword "..RATING},
-	["2H_SWORD_WEAPON_RATING"] = {"Two-Handed Sword "..SKILL.." "..RATING, "2H Sword "..RATING},
-	["AXE_WEAPON_RATING"] = {"Axe "..SKILL.." "..RATING, "Axe "..RATING},
-	["2H_AXE_WEAPON_RATING"] = {"Two-Handed Axe "..SKILL.." "..RATING, "2H Axe "..RATING},
-	["MACE_WEAPON_RATING"] = {"Mace "..SKILL.." "..RATING, "Mace "..RATING},
-	["2H_MACE_WEAPON_RATING"] = {"Two-Handed Mace "..SKILL.." "..RATING, "2H Mace "..RATING},
-	["GUN_WEAPON_RATING"] = {"Gun "..SKILL.." "..RATING, "Gun "..RATING},
-	["CROSSBOW_WEAPON_RATING"] = {"Crossbow "..SKILL.." "..RATING, "Crossbow "..RATING},
-	["BOW_WEAPON_RATING"] = {"Bow "..SKILL.." "..RATING, "Bow "..RATING},
-	["FERAL_WEAPON_RATING"] = {"Feral "..SKILL.." "..RATING, "Feral "..RATING},
-	["FIST_WEAPON_RATING"] = {"Unarmed "..SKILL.." "..RATING, "Unarmed "..RATING},
+	["DEFENSE_RATING"] = {"Score de défense", "Défense"},
+	["DODGE_RATING"] = {"Score d'esquive", "Esquive"},
+	["PARRY_RATING"] = {"Score de parade", "Parade"},
+	["BLOCK_RATING"] = {"Score de blocage", "Blocage"},
+	["MELEE_HIT_RATING"] = {"Score de toucher en mêlée", "Toucher (mêlée)"},
+	["RANGED_HIT_RATING"] = {"Score de toucher à distance", "Toucher (dist.)"},
+	["SPELL_HIT_RATING"] = {"Score de toucher des sorts", "Toucher (sorts)"},
+	["MELEE_HIT_AVOID_RATING"] = {"Score d'évitement des coups en mêlée", "Évi. des coups (mêlée)"},
+	["RANGED_HIT_AVOID_RATING"] = {"Score d'évitement des coups à distance", "Évi. des coups (dist.)"},
+	["SPELL_HIT_AVOID_RATING"] = {"Score d'évitement des coups des sorts", "Évi. des coups (sorts)"},
+	["MELEE_CRIT_RATING"] = {"Score de coup critique en mêlée", "Crit. (mêlée)"},
+	["RANGED_CRIT_RATING"] = {"Score de coup critique à distance", "Crit. (dist.)"},
+	["SPELL_CRIT_RATING"] = {"Score de coup critique des sorts", "Crit. (sorts)"},
+	["MELEE_CRIT_AVOID_RATING"] = {"Score d'évitement des critiques en mêlée", "Évi. des crit. (mêlée)"},
+	["RANGED_CRIT_AVOID_RATING"] = {"Score d'évitement des critiques à distance", "Évi. des crit. (dist.)"},
+	["SPELL_CRIT_AVOID_RATING"] = {"Score d'évitement des critiques des sorts", "Évi. des crit. (sorts)"},
+	["RESILIENCE_RATING"] = {"Score de résilience", "Résilience"},
+	["MELEE_HASTE_RATING"] = {"Score de hâte en mêlée", "Hâte (mêlée)"},
+	["RANGED_HASTE_RATING"] = {"Score de hâte à distance", "Hâte (dist.)"},
+	["SPELL_HASTE_RATING"] = {"Score de hâte des sorts","Hâte (sorts)"},
+	["DAGGER_WEAPON_RATING"] = {"Compétence en Dagues", "Dagues"},
+	["SWORD_WEAPON_RATING"] = {"Compétence en Epées à une main", "Epées à une main"},
+	["2H_SWORD_WEAPON_RATING"] = {"Compétence en Epées à deux mains", "Epées à deux mains"},
+	["AXE_WEAPON_RATING"] = {"Compétence en Haches à une main", "Haches à une main"},
+	["2H_AXE_WEAPON_RATING"] = {"Compétence en Haches à deux mains", "Haches à deux mains"},
+	["MACE_WEAPON_RATING"] = {"Compétence en Masses à une main", "Masses à une main"},
+	["2H_MACE_WEAPON_RATING"] = {"Compétence en Masses à deux mains", "Masses à deux mains"},
+	["GUN_WEAPON_RATING"] = {"Compétence en Armes à feu", "Armes à feu"}, --may become Fusils at some point in later expansions
+	["CROSSBOW_WEAPON_RATING"] = {"Compétence en Arbalètes", "Arbalètes"},
+	["BOW_WEAPON_RATING"] = {"Compétence en Arcs", "Arcs"},
+	["FERAL_WEAPON_RATING"] = {"Compétence en Combat farouche", "Combat farouche"}, --found Changeforme too
+	["FIST_WEAPON_RATING"] = {"Compétence en Armes de pugilat", "Armes de pugilat"}, --fist weapon =/= unarmed
+	--["UNARMED_WEAPON_RATING"] = {"Compétence en Mains nues", "Mains nues"},
+	--["POLEARMS_WEAPON_RATING"] = {"Compétence en Armes d'hast", "Armes d'hast"}, --may be useless but better have it than not
 
 	---------------------------------------------------------------------------
 	-- Tier2 Stats - Stats that only show up when broken down from a Tier1 stat
@@ -566,56 +569,58 @@ D["StatIDToName"] = {
 	-- Int -> Mana, Spell Crit
 	-- Spi -> mp5nc, hp5oc
 	-- Ratings -> Effect
-	["HEALTH_REG_OUT_OF_COMBAT"] = {HEALTH.." Regen (Out of combat)", "HP5(OC)"},
-	["MANA_REG_NOT_CASTING"] = {MANA.." Regen (Not casting)", "MP5(NC)"},
-	["MELEE_CRIT_DMG_REDUCTION"] = {"Crit Damage Reduction(%)", "Crit Dmg Reduc(%)"},
-	["RANGED_CRIT_DMG_REDUCTION"] = {PLAYERSTAT_RANGED_COMBAT.." Crit Damage Reduction(%)", PLAYERSTAT_RANGED_COMBAT.." Crit Dmg Reduc(%)"},
-	["SPELL_CRIT_DMG_REDUCTION"] = {PLAYERSTAT_SPELL_COMBAT.." Crit Damage Reduction(%)", PLAYERSTAT_SPELL_COMBAT.." Crit Dmg Reduc(%)"},
-	["DEFENSE"] = {DEFENSE, "Def"},
-	["DODGE"] = {DODGE.."(%)", DODGE.."(%)"},
-	["PARRY"] = {PARRY.."(%)", PARRY.."(%)"},
-	["BLOCK"] = {BLOCK.."(%)", BLOCK.."(%)"},
-	["MELEE_HIT"] = {"Hit Chance(%)", "Hit(%)"},
-	["RANGED_HIT"] = {PLAYERSTAT_RANGED_COMBAT.." Hit Chance(%)", PLAYERSTAT_RANGED_COMBAT.." Hit(%)"},
-	["SPELL_HIT"] = {PLAYERSTAT_SPELL_COMBAT.." Hit Chance(%)", PLAYERSTAT_SPELL_COMBAT.." Hit(%)"},
-	["MELEE_HIT_AVOID"] = {"Hit Avoidance(%)", "Hit Avd(%)"},
-	["RANGED_HIT_AVOID"] = {PLAYERSTAT_RANGED_COMBAT.." Hit Avoidance(%)", PLAYERSTAT_RANGED_COMBAT.." Hit Avd(%)"},
-	["SPELL_HIT_AVOID"] = {PLAYERSTAT_SPELL_COMBAT.." Hit Avoidance(%)", PLAYERSTAT_SPELL_COMBAT.." Hit Avd(%)"},
-	["MELEE_CRIT"] = {MELEE_CRIT_CHANCE.."(%)", "Crit(%)"}, -- MELEE_CRIT_CHANCE = "Crit Chance"
-	["RANGED_CRIT"] = {PLAYERSTAT_RANGED_COMBAT.." "..MELEE_CRIT_CHANCE.."(%)", PLAYERSTAT_RANGED_COMBAT.." Crit(%)"},
-	["SPELL_CRIT"] = {PLAYERSTAT_SPELL_COMBAT.." "..MELEE_CRIT_CHANCE.."(%)", PLAYERSTAT_SPELL_COMBAT.." Crit(%)"},
-	["MELEE_CRIT_AVOID"] = {"Crit Avoidance(%)", "Crit Avd(%)"},
-	["RANGED_CRIT_AVOID"] = {PLAYERSTAT_RANGED_COMBAT.." Crit Avoidance(%)", PLAYERSTAT_RANGED_COMBAT.." Crit Avd(%)"},
-	["SPELL_CRIT_AVOID"] = {PLAYERSTAT_SPELL_COMBAT.." Crit Avoidance(%)", PLAYERSTAT_SPELL_COMBAT.." Crit Avd(%)"},
-	["MELEE_HASTE"] = {"Haste(%)", "Haste(%)"}, --
-	["RANGED_HASTE"] = {PLAYERSTAT_RANGED_COMBAT.." Haste(%)", PLAYERSTAT_RANGED_COMBAT.." Haste(%)"},
-	["SPELL_HASTE"] = {PLAYERSTAT_SPELL_COMBAT.." Haste(%)", PLAYERSTAT_SPELL_COMBAT.." Haste(%)"},
-	["DAGGER_WEAPON"] = {"Dagger "..SKILL, "Dagger"}, -- SKILL = "Skill"
-	["SWORD_WEAPON"] = {"Sword "..SKILL, "Sword"},
-	["2H_SWORD_WEAPON"] = {"Two-Handed Sword "..SKILL, "2H Sword"},
-	["AXE_WEAPON"] = {"Axe "..SKILL, "Axe"},
-	["2H_AXE_WEAPON"] = {"Two-Handed Axe "..SKILL, "2H Axe"},
-	["MACE_WEAPON"] = {"Mace "..SKILL, "Mace"},
-	["2H_MACE_WEAPON"] = {"Two-Handed Mace "..SKILL, "2H Mace"},
-	["GUN_WEAPON"] = {"Gun "..SKILL, "Gun"},
-	["CROSSBOW_WEAPON"] = {"Crossbow "..SKILL, "Crossbow"},
-	["BOW_WEAPON"] = {"Bow "..SKILL, "Bow"},
-	["FERAL_WEAPON"] = {"Feral "..SKILL, "Feral"},
-	["FIST_WEAPON"] = {"Unarmed "..SKILL, "Unarmed"},
+	["HEALTH_REG_OUT_OF_COMBAT"] = {"Régén. vie (hors combat)", "HP5(HC)"},
+	["MANA_REG_NOT_CASTING"] = {"Régén. mana (hors incantation)", "MP5(HI)"},
+	["MELEE_CRIT_DMG_REDUCTION"] = {"Diminution des dégâts des coups critiques en mêlée (%)", "Dim. dégâts crit. (mêlée)(%)"},
+	["RANGED_CRIT_DMG_REDUCTION"] = {"Diminution des dégâts des coups critiques à distance (%)", "Dim. dégâts crit. (dist.)(%)"},
+	["SPELL_CRIT_DMG_REDUCTION"] = {"Diminution des dégâts des coups critiques des sorts (%)", "Dim. dégâts crit. (sorts)(%)"},
+	["DEFENSE"] = {"Défense", "Défense"},
+	["DODGE"] = {"Esquive (%)", "Esquive (%)"},
+	["PARRY"] = {"Parade (%)", "Parade (%)"},
+	["BLOCK"] = {"Blocage (%)", "Blocage (%)"},
+	["MELEE_HIT"] = {"Toucher en mêlée (%)", "Toucher (mêlée)(%)"},
+	["RANGED_HIT"] = {"Toucher à distance (%)", " Toucher (dist.)(%)"},
+	["SPELL_HIT"] = {"Toucher des sorts (%)", "Toucher (sorts)(%)"},
+	["MELEE_HIT_AVOID"] = {"Score d'évitement des coups en mêlée (%)", "Évi. des coups (mêlée)(%)"},
+	["RANGED_HIT_AVOID"] = {"Score d'évitement des coups à distance (%)","Évi. des coups (dist.)(%)"},
+	["SPELL_HIT_AVOID"] = {"Score d'évitement des coups des sorts (%)","Évi. des coups (sorts)(%)"},
+	["MELEE_CRIT"] = {"Critiques en mêlée (%)", "Crit. (mêlée)(%)"},
+	["RANGED_CRIT"] = {"Critiques à distance (%)", "Crit. (dist.)(%)"},
+	["SPELL_CRIT"] = {"Critiques des sorts (%)", "Crit. (sorts)(%)"},
+	["MELEE_CRIT_AVOID"] = {"Évitement des critiques en mêlée", "Évi. des crit. (mêlée)(%)"},
+	["RANGED_CRIT_AVOID"] = {"Évitement des critiques à distance", "Évi. des crit. (dist.)(%)"},
+	["SPELL_CRIT_AVOID"] = {"Évitement des critiques des sorts", "Évi. des crit. (sorts)(%)"},
+	["MELEE_HASTE"] = {"Hâte en mêlée (%)", "Hâte (mêlée)(%)"}, --
+	["RANGED_HASTE"] = {"Hâte à distance (%)", "Hâte (dist.)(%)"},
+	["SPELL_HASTE"] = {"Hâte des sorts (%)", " Hâte (sorts)(%)"},
+	["DAGGER_WEAPON"] = {"Compétence en Dagues", "Dagues"},
+	["SWORD_WEAPON"] = {"Compétence en Epées à une main", "Epées à une main"},
+	["2H_SWORD_WEAPON"] = {"Compétence en Epées à deux mains", "Epées à deux mains"},
+	["AXE_WEAPON"] = {"Compétence en Haches à une main", "Haches à une main"},
+	["2H_AXE_WEAPON"] = {"Compétence en Haches à deux mains", "Haches à deux mains"},
+	["MACE_WEAPON"] = {"Compétence en Masses à une main", "Masses à une main"},
+	["2H_MACE_WEAPON"] = {"Compétence en Masses à deux mains", "Masses à deux mains"},
+	["GUN_WEAPON"] = {"Compétence en Armes à feu", "Armes à feu"},
+	["CROSSBOW_WEAPON"] = {"Compétence en Arbalètes", "Arbalètes"},
+	["BOW_WEAPON"] = {"Compétence en Arcs", "Arcs"},
+	["FERAL_WEAPON"] = {"Compétence en Combat farouche", "Combat farouche"},
+	["FIST_WEAPON"] = {"Compétence en Armes de pugilat", "Armes de pugilat"},
+	--["UNARMED_WEAPON"] = {"Compétence en Mains nues", "Mains nues"},
+	--["POLEARMS_WEAPON"] = {"Compétence en Armes d'hast", "Armes d'hast"},
 
 	---------------------------------------------------------------------------
 	-- Tier3 Stats - Stats that only show up when broken down from a Tier2 stat
 	-- Defense -> Crit Avoidance, Hit Avoidance, Dodge, Parry, Block
 	-- Weapon Skill -> Crit, Hit, Dodge Neglect, Parry Neglect, Block Neglect
-	["DODGE_NEGLECT"] = {DODGE.." Neglect(%)", DODGE.." Neglect(%)"},
-	["PARRY_NEGLECT"] = {PARRY.." Neglect(%)", PARRY.." Neglect(%)"},
-	["BLOCK_NEGLECT"] = {BLOCK.." Neglect(%)", BLOCK.." Neglect(%)"},
+	["DODGE_NEGLECT"] = {"Diminution d'Esquive (%)", "Diminution d'Esquive (%)"},
+	["PARRY_NEGLECT"] = {"Diminution de Parade (%)", "Diminution de Parade (%)"},
+	["BLOCK_NEGLECT"] = {"Diminution de Blocage (%)", "Diminution de Blocage (%)"},
 
 	---------------------------------------------------------------------------
 	-- Talants
-	["MELEE_CRIT_DMG"] = {"Crit Damage(%)", "Crit Dmg(%)"},
-	["RANGED_CRIT_DMG"] = {PLAYERSTAT_RANGED_COMBAT.." Crit Damage(%)", PLAYERSTAT_RANGED_COMBAT.." Crit Dmg(%)"},
-	["SPELL_CRIT_DMG"] = {PLAYERSTAT_SPELL_COMBAT.." Crit Damage(%)", PLAYERSTAT_SPELL_COMBAT.." Crit Dmg(%)"},
+	["MELEE_CRIT_DMG"] = {"Dégâts des critiques en mêlée(%)", "Dégâts crit. (mêlée)(%)"},
+	["RANGED_CRIT_DMG"] = {"Dégâts des critiques à distance(%)", "Dégâts crit. (distance)(%)"},
+	["SPELL_CRIT_DMG"] = {"Dégâts des critiques des sorts(%)", "Dégâts crit. (sorts)(%)"},
 
 	---------------------------------------------------------------------------
 	-- Spell Stats
@@ -623,45 +628,44 @@ D["StatIDToName"] = {
 	-- Ex: "Heroic Strike@RAGE_COST" for Heroic Strike rage cost
 	-- Ex: "Heroic Strike@THREAT" for Heroic Strike threat value
 	-- Use strsplit("@", text) to seperate the spell name and statid
-	["THREAT"] = {"Threat", "Threat"},
-	["CAST_TIME"] = {"Casting Time", "Cast Time"},
-	["MANA_COST"] = {"Mana Cost", "Mana Cost"},
-	["RAGE_COST"] = {"Rage Cost", "Rage Cost"},
-	["ENERGY_COST"] = {"Energy Cost", "Energy Cost"},
-	["COOLDOWN"] = {"Cooldown", "CD"},
+	["THREAT"] = {"Menace", "Menace"},
+	["CAST_TIME"] = {"Temps d'incantation", "Temps d'incantation"},
+	["MANA_COST"] = {"Coût en mana", "Coût Mana"},
+	["RAGE_COST"] = {"Coût en rage", "Coût Rage"},
+	["ENERGY_COST"] = {"Coût en énergie", "Coût Énergie"},
+	["COOLDOWN"] = {"Temps de recharge", "CD"},
 
 	---------------------------------------------------------------------------
 	-- Stats Mods
-	["MOD_STR"] = {"Mod "..SPELL_STAT1_NAME.."(%)", "Mod Str(%)"},
-	["MOD_AGI"] = {"Mod "..SPELL_STAT2_NAME.."(%)", "Mod Agi(%)"},
-	["MOD_STA"] = {"Mod "..SPELL_STAT3_NAME.."(%)", "Mod Sta(%)"},
-	["MOD_INT"] = {"Mod "..SPELL_STAT4_NAME.."(%)", "Mod Int(%)"},
-	["MOD_SPI"] = {"Mod "..SPELL_STAT5_NAME.."(%)", "Mod Spi(%)"},
-	["MOD_HEALTH"] = {"Mod "..HEALTH.."(%)", "Mod "..HP.."(%)"},
-	["MOD_MANA"] = {"Mod "..MANA.."(%)", "Mod "..MP.."(%)"},
-	["MOD_ARMOR"] = {"Mod "..ARMOR.."from Items".."(%)", "Mod "..ARMOR.."(Items)".."(%)"},
-	["MOD_BLOCK_VALUE"] = {"Mod Block Value".."(%)", "Mod Block Value".."(%)"},
-	["MOD_DMG"] = {"Mod Damage".."(%)", "Mod Dmg".."(%)"},
-	["MOD_DMG_TAKEN"] = {"Mod Damage Taken".."(%)", "Mod Dmg Taken".."(%)"},
-	["MOD_CRIT_DAMAGE"] = {"Mod Crit Damage".."(%)", "Mod Crit Dmg".."(%)"},
-	["MOD_CRIT_DAMAGE_TAKEN"] = {"Mod Crit Damage Taken".."(%)", "Mod Crit Dmg Taken".."(%)"},
-	["MOD_THREAT"] = {"Mod Threat".."(%)", "Mod Threat".."(%)"},
-	["MOD_AP"] = {"Mod "..ATTACK_POWER_TOOLTIP.."(%)", "Mod AP".."(%)"},
-	["MOD_RANGED_AP"] = {"Mod "..PLAYERSTAT_RANGED_COMBAT.." "..ATTACK_POWER_TOOLTIP.."(%)", "Mod RAP".."(%)"},
-	["MOD_SPELL_DMG"] = {"Mod "..PLAYERSTAT_SPELL_COMBAT.." "..DAMAGE.."(%)", "Mod "..PLAYERSTAT_SPELL_COMBAT.." Dmg".."(%)"},
-	["MOD_HEALING"] = {"Mod Healing".."(%)", "Mod Heal".."(%)"},
-	["MOD_CAST_TIME"] = {"Mod Casting Time".."(%)", "Mod Cast Time".."(%)"},
-	["MOD_MANA_COST"] = {"Mod Mana Cost".."(%)", "Mod Mana Cost".."(%)"},
-	["MOD_RAGE_COST"] = {"Mod Rage Cost".."(%)", "Mod Rage Cost".."(%)"},
-	["MOD_ENERGY_COST"] = {"Mod Energy Cost".."(%)", "Mod Energy Cost".."(%)"},
-	["MOD_COOLDOWN"] = {"Mod Cooldown".."(%)", "Mod CD".."(%)"},
+	["MOD_STR"] = {"Mod Force (%)", "Mod For (%)"},
+	["MOD_AGI"] = {"Mod Agilité (%)", "Mod Agi (%)"},
+	["MOD_STA"] = {"Mod Endurance (%)", "Mod End (%)"},
+	["MOD_INT"] = {"Mod Intelligence (%)", "Mod Int (%)"},
+	["MOD_SPI"] = {"Mod Esprit (%)", "Mod Esp (%)"},
+	["MOD_HEALTH"] = {"Mod Points de vie (%)", "Mod PV (%)"},
+	["MOD_MANA"] = {"Mod Points de mana (%)", "Mod PM (%)"},
+	["MOD_ARMOR"] = {"Mod Armure des objets (%)", "Mod Armure (objets)(%)"},
+	["MOD_BLOCK_VALUE"] = {"Mod Valeur de blocage (%)", "Mod Valeur de blocage (%)"},
+	["MOD_DMG"] = {"Mod Damage (%)", "Mod Dmg (%)"},
+	["MOD_DMG_TAKEN"] = {"Mod Dégâts subis (%)", "Mod Dégâts subis (%)"},
+	["MOD_CRIT_DAMAGE"] = {"Mod Dégâts critiques (%)", "Mod Dégâts crit. (%)"},
+	["MOD_CRIT_DAMAGE_TAKEN"] = {"Mod Dégâts critiques subis (%)", "Mod Dégâts crit. subis (%)"},
+	["MOD_THREAT"] = {"Mod Menace (%)", "Mod Menace (%)"},
+	["MOD_AP"] = {"Mod Puissance d'attaque (%)", "Mod PA (%)"},
+	["MOD_RANGED_AP"] = {"Mod Puissance d'attaque à distance (%)", "Mod PA (dist.) (%)"},
+	["MOD_SPELL_DMG"] = {"Mod Dégâts des sorts (%)", "Mod Dégâts des sorts (%)"},
+	["MOD_HEALING"] = {"Mod Soins (%)", "Mod Soins (%)"},
+	["MOD_CAST_TIME"] = {"Mod Temps d'incantation (%)", "Mod Temps d'incantation (%)"},
+	["MOD_MANA_COST"] = {"Mod Coût en mana (%)", "Mod Coût Mana (%)"},
+	["MOD_RAGE_COST"] = {"Mod Coût en rage (%)", "Mod Coût Rage (%)"},
+	["MOD_ENERGY_COST"] = {"Mod Coût en énergie (%)", "Mod Coût Énergie (%)"},
+	["MOD_COOLDOWN"] = {"Mod Temps de recharge (%)", "Mod CD (%)"},
 
 	---------------------------------------------------------------------------
 	-- Misc Stats
-	["WEAPON_RATING"] = {"Weapon "..SKILL.." "..RATING, "Weapon"..SKILL.." "..RATING},
-	["WEAPON_SKILL"] = {"Weapon "..SKILL, "Weapon"..SKILL},
-	["MAINHAND_WEAPON_RATING"] = {"Main Hand Weapon "..SKILL.." "..RATING, "MH Weapon"..SKILL.." "..RATING},
-	["OFFHAND_WEAPON_RATING"] = {"Off Hand Weapon "..SKILL.." "..RATING, "OH Weapon"..SKILL.." "..RATING},
-	["RANGED_WEAPON_RATING"] = {"Ranged Weapon "..SKILL.." "..RATING, "Ranged Weapon"..SKILL.." "..RATING},
+	["WEAPON_RATING"] = {"Compétence d'arme", "Comp. d'arme"},
+	["WEAPON_SKILL"] = {"Compétence d'arme", "Comp. d'arme"},
+	["MAINHAND_WEAPON_RATING"] = {"Compétence d'arme en main droite", "Comp. d'arme main droite"},
+	["OFFHAND_WEAPON_RATING"] = {"Compétence d'arme en main gauche", "Comp. d'arme main gauche"},
+	["RANGED_WEAPON_RATING"] = {"Compétence d'arme à distance", "Comp. d'arme à distance"},
 }
-

--- a/libs/StatLogic-1.0/frFR.lua
+++ b/libs/StatLogic-1.0/frFR.lua
@@ -414,6 +414,7 @@ L["StatIDLookup"] = {
 
 	["score de hâte"] = {"MELEE_HASTE_RATING"},
 	["score de hâte des sorts"] = {"SPELL_HASTE_RATING"},
+	["le score de hâte des sorts"] = {"SPELL_HASTE_RATING"},
 	["score de hâte à distance"] = {"RANGED_HASTE_RATING"},
 	--["Improves haste rating"] = {"MELEE_HASTE_RATING"},
 	--["Improves melee haste rating"] = {"MELEE_HASTE_RATING"},

--- a/libs/StatLogic-1.0/frFR.lua
+++ b/libs/StatLogic-1.0/frFR.lua
@@ -310,6 +310,7 @@ L["StatIDLookup"] = {
 	["dégâts des sorts"] = {"SPELL_DMG",},
 	["aux sorts de soins"] = {"HEAL",},
 	["aux soins"] = {"HEAL",},
+	["aux soins et dégâts des sorts"] = {"HEAL", "SPELL_DMG"}, --shaman ZG enchant
 	["soins"] = {"HEAL",},
 	["les soins prodigués par les sorts et effets d’un maximum"] = {"HEAL",},
 

--- a/locales/frFR.lua
+++ b/locales/frFR.lua
@@ -342,8 +342,8 @@ L["Frost Resistance Summary"] = "Inclure la Résistance au givre."
 L["Sum Shadow Resistance"] = "Résistance : ombre"
 L["Shadow Resistance Summary"] = "Inclure la Résistance à l'ombre."
 -- /rb sum stat maxdamage
-L["Sum Weapon Max Damage"] = "Dégâts des armes"
-L["Weapon Max Damage Summary"] = "Inclure les dégâts des armes."
+L["Sum Weapon Max Damage"] = "Dégâts des armes max"
+L["Weapon Max Damage Summary"] = "Inclure la valeur la plus haute de la plage de dégâts des armes."
 -- /rb sum stat pen
 L["Sum Penetration"] = "Pénétration des sorts"
 L["Spell Penetration Summary"] = "Inclure la Pénétration des sorts."

--- a/locales/frFR.lua
+++ b/locales/frFR.lua
@@ -2,6 +2,7 @@
 Name: RatingBuster frFR locale (incomplete)
 Revision: $Revision: 73696 $
 Translated by: Tixu@Curse, Silaor, renchap
+
 --]]
 
 local L = LibStub("AceLocale-3.0"):NewLocale("RatingBuster", "frFR")
@@ -47,17 +48,17 @@ L["Options for Rating display"] = "Sélectionne les différents bonus liés aux 
 L["Show Rating conversions"] = "Aperçu conversion"
 L["Show Rating conversions in tooltips"] = "Ajoute la conversion des valeurs des différents scores dans les info-bulles des objets.\n\nCette case est requise pour l'affichage des scores détaillés."
 -- /rb rating detail
-L["Show detailed conversions text"] = "Résilience détaillée" --couldn't make this setting to apply to expertise, therefore i'm wording it for resilience only for now
-L["Show detailed text for Resiliance and Expertise conversions"] = "Convertis le score de résilience en pourcentage de réduction de coups critiques, réduction des dégâts critiques et réduction des dégâts périodiques."
+L["Show detailed conversions text"] = "Textes plus détaillés" 
+L["Show detailed text for Resiliance and Expertise conversions"] = "Rend la conversion des score de résilience et d'expertise plus précise.\n\nLa résilience indiquera le pourcentage d'évitement des coups critiques, réduction des dégâts critiques et réduction des dégâts périodiques.\n\nL'expertise indiquera le pourcentage de réduction du risque d'être esquivé et paré."
 -- /rb rating def
 L["Defense breakdown"] = "Défense détaillée"
-L["Convert Defense into Crit Avoidance, Hit Avoidance, Dodge, Parry and Block"] = "Convertis le score de défense en pourcentage de chance d'esquive, parade, blocage, réduction de coups critiques et réduction de toucher."
+L["Convert Defense into Crit Avoidance, Hit Avoidance, Dodge, Parry and Block"] = "Convertis le score de défense en pourcentage de chance d'esquive, parade, blocage, évitement des coups et évitement des coups critiques."
 -- /rb rating wpn
 L["Weapon Skill breakdown"] = "Comp. d'arme détaillée"
 L["Convert Weapon Skill into Crit, Hit, Dodge Neglect, Parry Neglect and Block Neglect"] = "Convertis le score de compétence d'arme en pourcentage de coups critiques, toucher, réduction d'esquive, réduction de parade et réduction de blocage."
 -- /rb rating exp -- 2.3.0
 L["Expertise breakdown"] = "Expertise détaillée"
-L["Convert Expertise into Dodge Neglect and Parry Neglect"] = "Convertis le score d'expertise en pourcentage de réduction d'esquive et réduction de parade."
+L["Convert Expertise into Dodge Neglect and Parry Neglect"] = "Convertis le score d'expertise en un pourcentage de réduction d'esquive et de parade."
 
 -- /rb stat
 L["Stat Breakdown"] = "Détail des caractéristiques"
@@ -75,8 +76,8 @@ L["Show Attack Power from Strength"] = "Affiche la Puissance d'attaque apportée
 L["Show Block Value"] = "Valeur de blocage"
 L["Show Block Value from Strength"] = "Affiche la Valeur de blocage apportée par la Force."
 -- /rb stat str dmg
-L["Show Spell Damage"] = "Puissance des sorts"
-L["Show Spell Damage from Strength"] = "Affiche la Puissance des sorts apportée par la Force."
+L["Show Spell Damage"] = "Dégâts des sorts"
+L["Show Spell Damage from Strength"] = "Affiche les Dégâts des sorts apportée par la Force."
 -- /rb stat str heal
 L["Show Healing"] = "Puissance des soins"
 L["Show Healing from Strength"] = "Affiche la Puissance des soins apportée par la Force."
@@ -110,8 +111,8 @@ L["Changes the display of Stamina"] = "Sélectionne les différents bonus liés 
 L["Show Health"] = "Points de vie"
 L["Show Health from Stamina"] = "Affiche les points de vie liés à l'Endurance."
 -- /rb stat sta dmg
-L["Show Spell Damage"] = "Puissance des sorts"
-L["Show Spell Damage from Stamina"] = "Affiche la Puissance des sorts apportée par l'Endurance."
+L["Show Spell Damage"] = "Dégâts des sorts"
+L["Show Spell Damage from Stamina"] = "Affiche les Dégâts des sorts apportée par l'Endurance."
 
 -- /rb stat int
 L["Intellect"] = "Intelligence"
@@ -123,8 +124,8 @@ L["Show Spell Crit chance from Intellect"] = "Affiche le pourcentage de Coups cr
 L["Show Mana"] = "Points de mana"
 L["Show Mana from Intellect"] = "Affiche les points de mana apportés par l'Intelligence."
 -- /rb stat int dmg
-L["Show Spell Damage"] = "Puissance des sorts"
-L["Show Spell Damage from Intellect"] = "Affiche la Puissance des sorts apportée par l'Intelligence."
+L["Show Spell Damage"] = "Dégâts des sorts"
+L["Show Spell Damage from Intellect"] = "Affiche les Dégâts des sorts apportée par l'Intelligence."
 -- /rb stat int heal
 L["Show Healing"] = "Puissance des soins"
 L["Show Healing from Intellect"] = "Affiche la Puissance des soins apportée par l'Intelligence."
@@ -154,8 +155,8 @@ L["Show Mana Regen while NOT casting from Spirit"] = "Affiche la Régénération
 L["Show Health Regen"] = "Hp5 (repos)"
 L["Show Health Regen from Spirit"] = "Affiche la Régénération de santé hors combat apportée par l'Esprit."
 -- /rb stat spi dmg
-L["Show Spell Damage"] = "Puissance des sorts"
-L["Show Spell Damage from Spirit"] = "Affiche la Puissance des sorts apportée par l'Esprit."
+L["Show Spell Damage"] = "Dégâts des sorts"
+L["Show Spell Damage from Spirit"] = "Affiche les Dégâts des sorts apportée par l'Esprit."
 -- /rb stat spi heal
 L["Show Healing"] = "Puissance des soins"
 L["Show Healing from Spirit"] = "Affiche la Puissance des soins apportée par l'Esprit."
@@ -165,7 +166,7 @@ L["Stat Summary"] = "Résumé des Stats"
 L["Options for stat summary"] = "Le résumé des différents bonus cumulés apportés par les statistiques peut être inclu dans les info-bulles des objets."
 -- /rb sum show
 L["Show stat summary"] = "Afficher le résumé"
-L["Show stat summary in tooltips"] = "Ajoute le résumé de tous les bonus provenant des différentes statistiques dans les info-bulle des objets."
+L["Show stat summary in tooltips"] = "Ajoute le résumé de tous les bonus provenant des différentes statistiques dans les info-bulles des objets."
 -- /rb sum ignore
 L["Ignore settings"] = "Valeurs à ignorer"
 L["Ignore stuff when calculating the stat summary"] = "Sélectionne les valeurs à ignorer lors des calculs du résumé."
@@ -212,8 +213,8 @@ L["Calculate the stat difference for the item and equipped items"] = "Ajoute une
 L["Sort StatSummary alphabetically"] = "Ordre alphabétique"
 L["Enable to sort StatSummary alphabetically, disable to sort according to stat type(basic, physical, spell, tank)"] = "Tri les statistiques par ordre alphabétique, plutôt que par ordre fixe (Basiques, Magiques, Physiques, Tank)."
 -- /rb sum avoidhasblock
-L["Include block chance in Avoidance summary"] = "Blocage dans Avoidance"
-L["Enable to include block chance in Avoidance summary, Disable for only dodge, parry, miss"] = "Inclue les chances de blocage au résumé Avoidance, en plus de l'esquive, de la parade et du raté.\n\nUtile pour les spécialisations tank disposant d'un bouclier."
+L["Include block chance in Avoidance summary"] = "Blocage dans Évitement"
+L["Enable to include block chance in Avoidance summary, Disable for only dodge, parry, miss"] = "Inclue les chances de blocage au résumé Évitement, en plus de l'esquive, de la parade et du raté.\n\nUtile pour les spécialisations tank disposant d'un bouclier."
 -- /rb sum basic
 L["Stat - Basic"] = "Stats - Basiques"
 L["Choose basic stats for summary"] = "Sélectionne les différentes caractéristiques basiques à prendre en compte lors des calculs du résumé."
@@ -242,26 +243,26 @@ L["Ranged Attack Power <- Ranged Attack Power, Intellect, Attack Power, Strength
 L["Sum Feral Attack Power"] = "PA farouche"
 L["Feral Attack Power <- Feral Attack Power, Attack Power, Strength, Agility"] = "Total Puissance d'attaque farouche = Puissance d'attaque farouche + Puissance d'attaque + Force + Agilité"
 -- /rb sum stat dmg
-L["Sum Spell Damage"] = "Puissance des sorts"
-L["Spell Damage <- Spell Damage, Intellect, Spirit, Stamina"] = "Total Puissance des sorts = Puissance des sorts + Intelligence + Esprit + Endurance"
+L["Sum Spell Damage"] = "Dégâts des sorts"
+L["Spell Damage <- Spell Damage, Intellect, Spirit, Stamina"] = "Total Dégâts des sorts = Dégâts des sorts + Intelligence + Esprit + Endurance"
 -- /rb sum stat dmgholy
-L["Sum Holy Spell Damage"] = "Puissance : sacré"
-L["Holy Spell Damage <- Holy Spell Damage, Spell Damage, Intellect, Spirit"] = "Total Puissance : sacré = Puissance : sacré + Puissance des sorts + Intelligence + Esprit"
+L["Sum Holy Spell Damage"] = "Dégâts : sacré"
+L["Holy Spell Damage <- Holy Spell Damage, Spell Damage, Intellect, Spirit"] = "Total Dégâts : sacré = Dégâts : sacré + Dégâts des sorts + Intelligence + Esprit"
 -- /rb sum stat dmgarcane
-L["Sum Arcane Spell Damage"] = "Puissance : arcanes"
-L["Arcane Spell Damage <- Arcane Spell Damage, Spell Damage, Intellect"] = "Total Puissance : arcanes = Puissance : arcanes + Puissance des sorts + Intelligence"
+L["Sum Arcane Spell Damage"] = "Dégâts : arcanes"
+L["Arcane Spell Damage <- Arcane Spell Damage, Spell Damage, Intellect"] = "Total Dégâts : arcanes = Dégâts : arcanes + Dégâts des sorts + Intelligence"
 -- /rb sum stat dmgfire
-L["Sum Fire Spell Damage"] = "Puissance : feu"
-L["Fire Spell Damage <- Fire Spell Damage, Spell Damage, Intellect, Stamina"] = "Total Puissance : feu = Puissance : feu + Puissance des sorts + Intelligence + Endurance"
+L["Sum Fire Spell Damage"] = "Dégâts : feu"
+L["Fire Spell Damage <- Fire Spell Damage, Spell Damage, Intellect, Stamina"] = "Total Dégâts : feu = Dégâts : feu + Dégâts des sorts + Intelligence + Endurance"
 -- /rb sum stat dmgnature
-L["Sum Nature Spell Damage"] = "Puissance : nature"
-L["Nature Spell Damage <- Nature Spell Damage, Spell Damage, Intellect"] = "Total Puissance : nature = Puissance : nature + Puissance des sorts + Intelligence"
+L["Sum Nature Spell Damage"] = "Dégâts : nature"
+L["Nature Spell Damage <- Nature Spell Damage, Spell Damage, Intellect"] = "Total Dégâts : nature = Dégâts : nature + Dégâts des sorts + Intelligence"
 -- /rb sum stat dmgfrost
-L["Sum Frost Spell Damage"] = "Puissance : givre"
-L["Frost Spell Damage <- Frost Spell Damage, Spell Damage, Intellect"] = "Total Puissance : givre = Puissance : givre + Puissance des sorts + Intelligence"
+L["Sum Frost Spell Damage"] = "Dégâts : givre"
+L["Frost Spell Damage <- Frost Spell Damage, Spell Damage, Intellect"] = "Total Dégâts : givre = Dégâts : givre + Dégâts des sorts + Intelligence"
 -- /rb sum stat dmgshadow
-L["Sum Shadow Spell Damage"] = "Puissance : ombre"
-L["Shadow Spell Damage <- Shadow Spell Damage, Spell Damage, Intellect, Spirit, Stamina"] = "Total Puissance : Ombre = Puissance : Ombre + Puissance des sorts + Intelligence + Esprit + Endurance"
+L["Sum Shadow Spell Damage"] = "Dégâts : ombre"
+L["Shadow Spell Damage <- Shadow Spell Damage, Spell Damage, Intellect, Spirit, Stamina"] = "Total Dégâts : Ombre = Dégâts : Ombre + Dégâts des sorts + Intelligence + Esprit + Endurance"
 -- /rb sum stat heal
 L["Sum Healing"] = "Puissance des soins"
 L["Healing <- Healing, Intellect, Spirit, Agility, Strength"] = "Total Puissance des soins = Puissance des soins + Intelligence + Esprit + Agilité + Force"
@@ -311,11 +312,11 @@ L["Parry Chance <- Parry Rating, Defense Rating"] = "Total Parade = Score de par
 L["Sum Block Chance"] = "Chance de blocage"
 L["Block Chance <- Block Rating, Defense Rating"] = "Total Chance de blocage = Score de blocage + Score de défense"
 -- /rb sum stat avoidhit
-L["Sum Hit Avoidance"] = "Raté"
-L["Hit Avoidance <- Defense Rating"] = "Total Raté = Score de défense"
+L["Sum Hit Avoidance"] = "Évitement des coups"
+L["Hit Avoidance <- Defense Rating"] = "Total Évitement des coups = Score de défense"
 -- /rb sum stat avoidcrit
-L["Sum Crit Avoidance"] = "Réduction Critique"
-L["Crit Avoidance <- Defense Rating, Resilience"] = "Total Réduction des Coups critiques = Score de défense + Résilience"
+L["Sum Crit Avoidance"] = "Évitement CC"
+L["Crit Avoidance <- Defense Rating, Resilience"] = "Total Évitement des Coups critiques = Score de défense + Résilience"
 -- /rb sum stat neglectdodge
 L["Sum Dodge Neglect"] = "Réduction Esquive"
 L["Dodge Neglect <- Expertise, Weapon Skill Rating"] = "Total Réduction d'esquive = Expertise + Compétence d'arme"
@@ -413,8 +414,8 @@ L["TankPoints <- Health, Total Reduction"] = "TankPoints = Vie + Réduction tota
 L["Sum Total Reduction"] = "Réduction complète"
 L["Total Reduction <- Armor, Dodge, Parry, Block, Block Value, Defense, Resilience, MobMiss, MobCrit, MobCrush, DamageTakenMods"] = "Total Réduction complète = Armure + Equive + Parade + Blocage + Valeur de blocage + Défense + Résilience + MobMiss, MobCrit, MobCrush, DamageTakenMods"
 -- /rb sum statcomp avoid
-L["Sum Avoidance"] = "Avoidance"
-L["Avoidance <- Dodge, Parry, MobMiss, Block(Optional)"] = "Total Avoidance = Esquive + Parade + Raté + Blocage(optionnel)"
+L["Sum Avoidance"] = "Évitement"
+L["Avoidance <- Dodge, Parry, MobMiss, Block(Optional)"] = "Total Évitement = Esquive + Parade + Raté + Blocage(optionnel)"
 -- /rb sum gem
 L["Gems"] = "Gemmes"
 L["Auto fill empty gem slots"] = "Remplir automatiquement les châsses."
@@ -560,8 +561,8 @@ L["statList"] = {
 	{pattern = "score de hâte des sorts", id = CR_HASTE_SPELL},
 	{pattern = "score de hâte à distance", id = CR_HASTE_RANGED},
 	{pattern = "score de hâte", id = CR_HASTE_MELEE},
-	{pattern = "score de hâte en mêlée", id = CR_HASTE_MELEE}, -- [Tambours de Bataille]
-
+	{pattern = "score de hâte en mêlée", id = CR_HASTE_MELEE}, -- [Tambours de Bataille] doesn't work
+	--{pattern = "score de hâte en mêlée, à distance et avec les sorts", id = CR_HASTE_SPELL}, --complete line for drums buff, doesn't work
 	{pattern = "score d’expertise", id = CR_EXPERTISE},
 	{pattern = "score d'expertise", id = CR_EXPERTISE},
 	{pattern = "score d'évitement des coups", id = CR_HIT_TAKEN_MELEE},

--- a/locales/frFR.lua
+++ b/locales/frFR.lua
@@ -1,38 +1,39 @@
-﻿--[[
+--[[
 Name: RatingBuster frFR locale (incomplete)
 Revision: $Revision: 73696 $
-Translated by:
-- Tixu@Curse
-- Silaor
-- renchap
-]]
+Translated by: Tixu@Curse, Silaor, renchap
+--]]
+
 local L = LibStub("AceLocale-3.0"):NewLocale("RatingBuster", "frFR")
 if not L then return end
-----
--- This file is coded in UTF-8
--- If you don't have a editor that can save in UTF-8, I recommend Ultraedit
-----
+L["RatingBuster Options"] = true
 ---------------------------
 -- Slash Command Options --
 ---------------------------
+-- /rb help
+L["Help"] = true
+L["Show this help message"] = true
+-- /rb win
+L["Options Window"] = "Fenêtre des options"
+L["Shows the Options Window"] = "Affiche la fenêtre des options"
 -- /rb statmod
 L["Enable Stat Mods"] = "Activer les Stat Mods"
 L["Enable support for Stat Mods"] = "Activer le support pour Stat Mods"
 -- /rb itemid
-L["Show ItemID"] = "Voire l'ID de l'objet"
-L["Show the ItemID in tooltips"] = "Montrer l'ID d'un objet dans l'infobulle"
+L["Show ItemID"] = "ID des objets"
+L["Show the ItemID in tooltips"] = "Affiche l'ID des objets dans les info-bulles."
 -- /rb itemlevel
-L["Show ItemLevel"] = "Voire le niveau de l'objet"
-L["Show the ItemLevel in tooltips"] = "Montre le niveau de l'objet dans l'infobulle"
+L["Show ItemLevel"] = "Niveau des objets"
+L["Show the ItemLevel in tooltips"] = "Affiche le niveau d'objet dans les info-bulles"
 -- /rb usereqlv
 L["Use required level"] = "Utiliser le niveau requis"
-L["Calculate using the required level if you are below the required level"] = "Effectue les calculs en utilisant le niveau requis par l'objet si il n'est pas atteint"
+L["Calculate using the required level if you are below the required level"] = "Effectue les calculs en utilisant le niveau requis par l'objet si il n'est pas atteint."
 -- /rb setlevel
 L["Set level"] = "Définir le niveau"
-L["Set the level used in calculations (0 = your level)"] = "Définit le niveau utilisé dans les calculs (0 = votre niveau)"
+L["Set the level used in calculations (0 = your level)"] = "Définis le niveau utilisé dans les calculs (0 = votre niveau)"
 -- /rb color
-L["Change text color"] = "Changer la couleur du texte"
-L["Changes the color of added text"] = "Change la couleur du texte ajouté"
+L["Change text color"] = "Couleur du texte"
+L["Changes the color of added text"] = "Change la couleur du texte ajouté."
 -- /rb color pick
 L["Pick color"] = "Choix de la couleur"
 L["Pick a color"] = "Choisissez une couleur"
@@ -40,320 +41,389 @@ L["Pick a color"] = "Choisissez une couleur"
 L["Enable color"] = "Activer la couleur"
 L["Enable colored text"] = "Active le texte coloré"
 -- /rb rating
-L["Rating"] = "Score"
-L["Options for Rating display"] = "Options pour l'affichage des scores"
+L["Rating"] = "Détail des scores"
+L["Options for Rating display"] = "Sélectionne les différents bonus liés aux scores à inclure dans les info-bulles des objets."
 -- /rb rating show
-L["Show Rating conversions"] = "Montrer la conversion des scores"
-L["Show Rating conversions in tooltips"] = "Montre dans l'infobulle les gains apportés par le score"
+L["Show Rating conversions"] = "Aperçu conversion"
+L["Show Rating conversions in tooltips"] = "Ajoute la conversion des valeurs des différents scores dans les info-bulles des objets.\n\nCette case est requise pour l'affichage des scores détaillés."
+-- /rb rating detail
+L["Show detailed conversions text"] = "Résilience détaillée" --couldn't make this setting to apply to expertise, therefore i'm wording it for resilience only for now
+L["Show detailed text for Resiliance and Expertise conversions"] = "Convertis le score de résilience en pourcentage de réduction de coups critiques, réduction des dégâts critiques et réduction des dégâts périodiques."
 -- /rb rating def
-L["Defense breakdown"] = "Détailler la défense"
-L["Convert Defense into Crit Avoidance Hit Avoidance, Dodge, Parry and Block"] = "Convertit le score de défense en Défense Crit, Défense Coup, Esquive, Parade et Bloquage"
+L["Defense breakdown"] = "Défense détaillée"
+L["Convert Defense into Crit Avoidance, Hit Avoidance, Dodge, Parry and Block"] = "Convertis le score de défense en pourcentage de chance d'esquive, parade, blocage, réduction de coups critiques et réduction de toucher."
 -- /rb rating wpn
-L["Weapon Skill breakdown"] = "Détailler la compétence d'arme"
-L["Convert Weapon Skill into Crit Hit, Dodge Neglect, Parry Neglect and Block Neglect"] = "Convertit la compétence d'arme en Critique, Toucher, Ignorer Esquive, Ignorer Parade, Ignorer Bloquage"
+L["Weapon Skill breakdown"] = "Comp. d'arme détaillée"
+L["Convert Weapon Skill into Crit, Hit, Dodge Neglect, Parry Neglect and Block Neglect"] = "Convertis le score de compétence d'arme en pourcentage de coups critiques, toucher, réduction d'esquive, réduction de parade et réduction de blocage."
+-- /rb rating exp -- 2.3.0
+L["Expertise breakdown"] = "Expertise détaillée"
+L["Convert Expertise into Dodge Neglect and Parry Neglect"] = "Convertis le score d'expertise en pourcentage de réduction d'esquive et réduction de parade."
 
 -- /rb stat
---["Stat Breakdown"] = "Carac",
-L["Changes the display of base stats"] = "Change l'affichage des caractéristiques de base"
+L["Stat Breakdown"] = "Détail des caractéristiques"
+L["Changes the display of base stats"] = "Sélectionne les différents bonus liés aux caractéristiques principales à inclure dans les info-bulles des objets."
 -- /rb stat show
-L["Show base stat conversions"] = "Montrer les conversions pour les caracs"
-L["Show base stat conversions in tooltips"] = "Montre dans l'infobulle les caracs converties"
+L["Show base stat conversions"] = "Aperçu détaillé"
+L["Show base stat conversions in tooltips"] = "Ajoute un aperçu détaillé des différents bonus liés aux caractéristiques principales dans les info-bulles des objets.\n\nCette case est requise pour l'affichage des différents bonus liés à l'agilité, l'endurance, l'esprit, la force et l'intelligence."
 -- /rb stat str
 L["Strength"] = "Force"
-L["Changes the display of Strength"] = "Change l'affichage de la Force"
+L["Changes the display of Strength"] = "Sélectionne les différents bonus liés à la Force."
 -- /rb stat str ap
-L["Show Attack Power"] = "Montrer la PA"
-L["Show Attack Power from Strength"] = "Montre la Puissance d'Attaque apporté par la Force"
+L["Show Attack Power"] = "Puisance d'attaque"
+L["Show Attack Power from Strength"] = "Affiche la Puissance d'attaque apportée par la Force."
 -- /rb stat str block
-L["Show Block Value"] = "Montrer le Bloquage"
-L["Show Block Value from Strength"] = "Montre le Bloquage apporté par la Force"
+L["Show Block Value"] = "Valeur de blocage"
+L["Show Block Value from Strength"] = "Affiche la Valeur de blocage apportée par la Force."
 -- /rb stat str dmg
-L["Show Spell Damage"] = "Montrer les Dégats des Sorts"
-L["Show Spell Damage from Strength"] = "Montre le Bonus de Dégats des Sorts apporté par la Force"
+L["Show Spell Damage"] = "Puissance des sorts"
+L["Show Spell Damage from Strength"] = "Affiche la Puissance des sorts apportée par la Force."
 -- /rb stat str heal
-L["Show Healing"] = "Montrer les Soins"
-L["Show Healing from Strength"] = "Montre le Bonus aux Soins apportés par la Force"
+L["Show Healing"] = "Puissance des soins"
+L["Show Healing from Strength"] = "Affiche la Puissance des soins apportée par la Force."
 
--- /rb stat agi
+-- /rb stat Agilité
 L["Agility"] = "Agilité"
-L["Changes the display of Agility"] = "Change l'affichage de l'Agilité"
--- /rb stat agi crit
-L["Show Crit"] = "Montrer le %Crit"
-L["Show Crit chance from Agility"] = "Montre le pourcentage de critique apporté par l'Agilité"
--- /rb stat agi dodge
-L["Show Dodge"] = "Montrer l'Esquive"
-L["Show Dodge chance from Agility"] = "Montre les chances d'Esquive apportées par l'Agilité"
--- /rb stat agi ap
-L["Show Attack Power"] = "Montrer la PA"
-L["Show Attack Power from Agility"] = "Montre la Puissance d'Attaque apporté par l'Agilité"
--- /rb stat agi rap
-L["Show Ranged Attack Power"] = "Montrer la PA à Distance"
-L["Show Ranged Attack Power from Agility"] = "Montre la Puissance d'Attaque à Distance apporté par l'Agilité"
--- /rb stat agi armor
-L["Show Armor"] = "Montrer l'Armure"
-L["Show Armor from Agility"] = "Montre l'Armure apportée par l'Agilité"
--- /rb stat agi heal
-L["Show Healing"] = "Montrer les Soins"
-L["Show Healing from Agility"] = "Montre le bonus aux Soins apporté par l'Agilité"
+L["Changes the display of Agility"] = "Sélectionne les différents bonus liés à l'Agilité."
+-- /rb stat Agilité crit
+L["Show Crit"] = "Critique (%)"
+L["Show Crit chance from Agility"] = "Affiche le pourcentage de Coups critiques apporté par l'Agilité."
+-- /rb stat Agilité dodge
+L["Show Dodge"] = "Esquive (%)"
+L["Show Dodge chance from Agility"] = "Affiche le poucentage d'Esquive apporté par l'Agilité."
+-- /rb stat Agilité ap
+L["Show Attack Power"] = "Puissance d'attaque"
+L["Show Attack Power from Agility"] = "Affiche la Puissance d'attaque apportée par l'Agilité."
+-- /rb stat Agilité rap
+L["Show Ranged Attack Power"] = "PA à distance"
+L["Show Ranged Attack Power from Agility"] = "Affiche la Puissance d'attaque à distance apportée par l'Agilité."
+-- /rb stat Agilité armor
+L["Show Armor"] = "Armure"
+L["Show Armor from Agility"] = "Affiche l'Armure apportée par l'Agilité."
+-- /rb stat Agilité heal
+L["Show Healing"] = "Puissance des soins"
+L["Show Healing from Agility"] = "Affiche la Puissance des soins apportée par l'Agilité."
 
 -- /rb stat sta
 L["Stamina"] = "Endurance"
-L["Changes the display of Stamina"] = "Change l'affichage de l'Endurance"
+L["Changes the display of Stamina"] = "Sélectionne les différents bonus liés à l'Endurance."
 -- /rb stat sta hp
-L["Show Health"] = "Montrer les PV"
-L["Show Health from Stamina"] = "Montre les Points de Vie apportés par l'Endurance"
+L["Show Health"] = "Points de vie"
+L["Show Health from Stamina"] = "Affiche les points de vie liés à l'Endurance."
 -- /rb stat sta dmg
-L["Show Spell Damage"] = "Montrer les Dégats des Sorts"
-L["Show Spell Damage from Stamina"] = "Montre le bonus de Dégats des Sorts apporté par l'Endurance"
+L["Show Spell Damage"] = "Puissance des sorts"
+L["Show Spell Damage from Stamina"] = "Affiche la Puissance des sorts apportée par l'Endurance."
 
 -- /rb stat int
 L["Intellect"] = "Intelligence"
-L["Changes the display of Intellect"] = "Change l'affichage de l'Intelligence"
+L["Changes the display of Intellect"] = "Sélectionne les différents bonus liés à l'Intelligence."
 -- /rb stat int spellcrit
-L["Show Spell Crit"] = "Montrer le %Crit des Sorts"
-L["Show Spell Crit chance from Intellect"] = "Montre le Pourcentage de Critique des Sorts apporté par l'Intelligence"
+L["Show Spell Crit"] = "Critique des sorts (%)"
+L["Show Spell Crit chance from Intellect"] = "Affiche le pourcentage de Coups critiques des sorts apporté par l'Intelligence."
 -- /rb stat int mp
-L["Show Mana"] = "Montrer les PM"
-L["Show Mana from Intellect"] = "Montre les Points de Mana apportés par l'Intelligence"
+L["Show Mana"] = "Points de mana"
+L["Show Mana from Intellect"] = "Affiche les points de mana apportés par l'Intelligence."
 -- /rb stat int dmg
-L["Show Spell Damage"] = "Montrer les Dégats des Sorts"
-L["Show Spell Damage from Intellect"] = "Montre le Bonus de Dégats des Sorts apporté par l'Intelligence"
+L["Show Spell Damage"] = "Puissance des sorts"
+L["Show Spell Damage from Intellect"] = "Affiche la Puissance des sorts apportée par l'Intelligence."
 -- /rb stat int heal
-L["Show Healing"] = "Montrer les Soins"
-L["Show Healing from Intellect"] = "Montre le Bonus aux Soins apportés par l'Intelligence"
+L["Show Healing"] = "Puissance des soins"
+L["Show Healing from Intellect"] = "Affiche la Puissance des soins apportée par l'Intelligence."
 -- /rb stat int mp5
-L["Show Mana Regen"] = "Montrer la Regen Mana"
-L["Show Mana Regen while casting from Intellect"] = "Montre la Régénération de Mana pendant incantation apportée par l'Intelligence"
+L["Show Mana Regen"] = "Mp5 (incantation)"
+L["Show Mana Regen while casting from Intellect"] = "Affiche la Régénération de mana pendant l'incantation des sorts apportée par l'Intelligence."
 -- /rb stat int mp5nc
---["Show Mana Regen while NOT casting"] = true,
---["Show Mana Regen while NOT casting from Intellect"] = true,
+L["Show Mana Regen while NOT casting"] = "Affiche la Régénération de mana hors incantation."
+L["Show Mana Regen while NOT casting from Intellect"] = "Affiche la Régénération de mana hors incantation apportée par l'Intelligence."
 -- /rb stat int rap
-L["Show Ranged Attack Power"] = "Montre la PA à Distance"
-L["Show Ranged Attack Power from Intellect"] = "Montre la Puissance d'Attaque à Distance apportée par l'Intelligence"
+L["Show Ranged Attack Power"] = "PA à distance"
+L["Show Ranged Attack Power from Intellect"] = "Affiche la Puissance d'attaque à distance apportée par l'Intelligence."
 -- /rb stat int armor
-L["Show Armor"] = "Montrer l'Armure"
-L["Show Armor from Intellect"] = "Montre l'Armure apportée par l'Intelligence"
+L["Show Armor"] = "Armure"
+L["Show Armor from Intellect"] = "Affiche l'Armure apportée par l'Intelligence."
 
 -- /rb stat spi
 L["Spirit"] = "Esprit"
-L["Changes the display of Spirit"] = "Change l'affichage de l'Esprit"
+L["Changes the display of Spirit"] = "Sélectionne les différents bonus liés à l'Esprit."
 -- /rb stat spi mp5
-L["Show Mana Regen"] = "Montrer la Regen Mana"
-L["Show Mana Regen while casting from Spirit"] = "Montre la Régénération de Mana pendant incantation apportée par l'Esprit"
+L["Show Mana Regen"] = "Mp5 (incantation)"
+L["Show Mana Regen while casting from Spirit"] = "Affiche la Régénération de mana pendant l'incantation des sorts apportée par l'Esprit."
 -- /rb stat spi mp5nc
-L["Show Mana Regen while NOT casting"] = "Montrer la Regen Mana (HI)"
-L["Show Mana Regen while NOT casting from Spirit"] = "Montre la Régénération de Mana HORS INCANTATION apportée par l'Epsrit"
+L["Show Mana Regen while NOT casting"] = "Mp5 (repos)"
+L["Show Mana Regen while NOT casting from Spirit"] = "Affiche la Régénération de mana au hors incantation apportée par l'Esprit."
 -- /rb stat spi hp5
-L["Show Health Regen"] = "Montrer la Regen PV"
-L["Show Health Regen from Spirit"] = "Montre la Régénération des Points de Vie apportée par l'Esprit"
+L["Show Health Regen"] = "Hp5 (repos)"
+L["Show Health Regen from Spirit"] = "Affiche la Régénération de santé hors combat apportée par l'Esprit."
 -- /rb stat spi dmg
-L["Show Spell Damage"] = "Montrer les Dégats des Sorts"
-L["Show Spell Damage from Spirit"] = "Montre le Bonus aux Soins apportés par l'Esprit"
+L["Show Spell Damage"] = "Puissance des sorts"
+L["Show Spell Damage from Spirit"] = "Affiche la Puissance des sorts apportée par l'Esprit."
 -- /rb stat spi heal
-L["Show Healing"] = "Montrer les Soins"
-L["Show Healing from Spirit"] = "Montre le Bonus aux Soins apportés par l'Esprit"
+L["Show Healing"] = "Puissance des soins"
+L["Show Healing from Spirit"] = "Affiche la Puissance des soins apportée par l'Esprit."
 
 -- /rb sum
 L["Stat Summary"] = "Résumé des Stats"
-L["Options for stat summary"] = "Options pour le Résumé"
+L["Options for stat summary"] = "Le résumé des différents bonus cumulés apportés par les statistiques peut être inclu dans les info-bulles des objets."
 -- /rb sum show
-L["Show stat summary"] = "Montrer le Résumé"
-L["Show stat summary in tooltips"] = "Montre le Résumé des Statistiques de combat dans l'infobulle"
+L["Show stat summary"] = "Afficher le résumé"
+L["Show stat summary in tooltips"] = "Ajoute le résumé de tous les bonus provenant des différentes statistiques dans les info-bulle des objets."
 -- /rb sum ignore
-L["Ignore settings"] = "Paramètres à ignorer"
-L["Ignore stuff when calculating the stat summary"] = "Choisir quoi ignorer lors du calcul du résumé de stats"
+L["Ignore settings"] = "Valeurs à ignorer"
+L["Ignore stuff when calculating the stat summary"] = "Sélectionne les valeurs à ignorer lors des calculs du résumé."
 -- /rb sum ignore unused
-L["Ignore unused items types"] = "Ignorer les types d'objets non utilisés"
-L["Show stat summary only for highest level armor type and items you can use with uncommon quality and up"] = "Montre les statistiques uniquement pour les plus hauts rangs d'armure et pour des objets de qualité au moins Inhabituel"
+L["Ignore unused items types"] = "Types d'objets non utilisables"
+L["Show stat summary only for highest level armor type and items you can use with uncommon quality and up"] = "N'affiche le résumé que sur les types d'armes et d'armures que votre classe peut utiliser et pour les équipements de qualité au moins Inhabituelle."
 -- /rb sum ignore equipped
-L["Ignore equipped items"] = "Ignorer les objets équipés"
-L["Hide stat summary for equipped items"] = "Cache le résumé pour les objets équipés"
+L["Ignore equipped items"] = "Objets équipés"
+L["Hide stat summary for equipped items"] = "Ne pas afficher le résumé pour les objets équipés."
 -- /rb sum ignore enchant
-L["Ignore enchants"] = "Ignorer les Enchantements"
-L["Ignore enchants on items when calculating the stat summary"] = "Ignore les bonus d'Enchantement lors du calcul du résumé"
+L["Ignore enchants"] = "Enchantements"
+L["Ignore enchants on items when calculating the stat summary"] = "Ignorer les bonus d'enchantement lors des calculs du résumé."
 -- /rb sum ignore gem
-L["Ignore gems"] = "Ignorer les Gemmes"
-L["Ignore gems on items when calculating the stat summary"] = "Ignore les bonus des Gemmes lors du calcul du résumé"
+L["Ignore gems"] = "Gemmes"
+L["Ignore gems on items when calculating the stat summary"] = "Ignorer les bonus des gemmes lors des calculs du résumé."
 -- /rb sum diffstyle
-L["Display style for diff value"] = "Style d'affichage du résumé"
-L["Display diff values in the main tooltip or only in compare tooltips"] = "Afficher les différences dans l'infobulle principale ou dans l'infobulle de comparaison"
---[[TODO
+L["Display style for diff value"] = "Mode d'affichage du comparatif"
+L["Display diff values in the main tooltip or only in compare tooltips"] = "Détermine si le comparatif s'ajoute à l'info-bulle principale ou à l'info-bulle de la pièce comparée."
 -- /rb sum space
-L["Add empty line"] = true
-L["Add a empty line before or after stat summary"] = true
+L["Add empty line"] = "Ajouter une ligne vide"
+L["Add a empty line before or after stat summary"] = "Ajoute une ligne vide avant et/ou après le résumé."
 -- /rb sum space before
-L["Add before summary"] = true
-L["Add a empty line before stat summary"] = true
+L["Add before summary"] = "Avant le résumé"
+L["Add a empty line before stat summary"] = "Ajoute une ligne vide avant le résumé des statistiques."
 -- /rb sum space after
-L["Add after summary"] = true
-L["Add a empty line after stat summary"] = true
+L["Add after summary"] = "Après le résumé"
+L["Add a empty line after stat summary"] = "Ajoute une ligne vide après le résumé des statistiques."
 -- /rb sum icon
-L["Show icon"] = true
-L["Show the sigma icon before summary listing"] = true
+L["Show icon"] = "Ajouter l'icône"
+L["Show the sigma icon before summary listing"] = "Affiche l'icône sigma avant le résumé."
 -- /rb sum title
-L["Show title text"] = true
-L["Show the title text before summary listing"] = true
---]]
+L["Show title text"] = "AJouter le titre"
+L["Show the title text before summary listing"] = "Ajoute le titre avant le résumé."
 -- /rb sum showzerostat
-L["Show zero value stats"] = "Montrer les stats nulles"
-L["Show zero value stats in summary for consistancy"] = "Montre les stats nulles pour plus de cohérence"
+L["Show zero value stats"] = "Ajouter les stats nulles"
+L["Show zero value stats in summary for consistancy"] = "Ajoute les stats nulles/absentes au résumé pour plus de cohérence."
 -- /rb sum calcsum
-L["Calculate stat sum"] = "Calculer les cumuls"
-L["Calculate the total stats for the item"] = "Fait un cumul des stats pour l'objet"
+L["Calculate stat sum"] = "Afficher les totaux"
+L["Calculate the total stats for the item"] = "Calcule et affiche le montant final de chaque statistique présente sur les objets."
 -- /rb sum calcdiff
-L["Calculate stat diff"] = "Calculer les différences"
-L["Calculate the stat difference for the item and equipped items"] = "Fait le calcul des différences avec l'objet équipé"
--- /rb sum stat
---["Stat - Base"] = "Stat Base",
---["Choose base stats for summary"] = "Choisir les Stats de base pour le Résumé",
+L["Calculate stat diff"] = "Comparaison"
+L["Calculate the stat difference for the item and equipped items"] = "Ajoute une comparaison entre les statistiques des objets et celles de l'équipement actuel."
+-- /rb sum sort
+L["Sort StatSummary alphabetically"] = "Ordre alphabétique"
+L["Enable to sort StatSummary alphabetically, disable to sort according to stat type(basic, physical, spell, tank)"] = "Tri les statistiques par ordre alphabétique, plutôt que par ordre fixe (Basiques, Magiques, Physiques, Tank)."
+-- /rb sum avoidhasblock
+L["Include block chance in Avoidance summary"] = "Blocage dans Avoidance"
+L["Enable to include block chance in Avoidance summary, Disable for only dodge, parry, miss"] = "Inclue les chances de blocage au résumé Avoidance, en plus de l'esquive, de la parade et du raté.\n\nUtile pour les spécialisations tank disposant d'un bouclier."
+-- /rb sum basic
+L["Stat - Basic"] = "Stats - Basiques"
+L["Choose basic stats for summary"] = "Sélectionne les différentes caractéristiques basiques à prendre en compte lors des calculs du résumé."
+-- /rb sum physical
+L["Stat - Physical"] = "Stats - Physiques"
+L["Choose physical damage stats for summary"] = "Sélectionne les différentes caractéristiques de combat physique à prendre en compte lors des calculs du résumé."
+-- /rb sum spell
+L["Stat - Spell"] = "Stats - Magiques"
+L["Choose spell damage and healing stats for summary"] = "Sélectionne les différentes caractéristiques de combat magique à prendre en compte lors des calculs du résumé."
+-- /rb sum tank
+L["Stat - Tank"] = "Stats - Tank"
+L["Choose tank stats for summary"] = "Sélectionne les différentes caractéristiques défensives à prendre en compte lors des calculs du résumé."
 -- /rb sum stat hp
-L["Sum Health"] = "Cumul Vie"
-L["Health <- Health Stamina"] = "Vie <- Vie, Endu"
+L["Sum Health"] = "Vie"
+L["Health <- Health, Stamina"] = "Total Vie = Vie + Endurance"
 -- /rb sum stat mp
-L["Sum Mana"] = "Cumul Mana"
-L["Mana <- Mana Intellect"] = "Mana <- Mana, Intel"
+L["Sum Mana"] = "Mana"
+L["Mana <- Mana, Intellect"] = "Total Mana = Mana + Intelligence"
 -- /rb sum stat ap
-L["Sum Attack Power"] = "Cumul PA"
-L["Attack Power <- Attack Power Strength, Agility"] = "PA <- PA, Force, Agi"
+L["Sum Attack Power"] = "Puissance d'attaque"
+L["Attack Power <- Attack Power, Strength, Agility"] = "Total Puissance d'attaque = Puissance d'attaque + Force + Agilité"
 -- /rb sum stat rap
-L["Sum Ranged Attack Power"] = "Cumul PA Dist"
-L["Ranged Attack Power <- Ranged Attack Power Intellect, Attack Power, Strength, Agility"] = "PA Dist <- PA Dist, Intel, PA, Force, Agi"
+L["Sum Ranged Attack Power"] = "PA à distance"
+L["Ranged Attack Power <- Ranged Attack Power, Intellect, Attack Power, Strength, Agility"] = "Total Puissance d'attaque à distance = Puissance d'attaque à distance + Intelligence + Puissance d'attaque + Force + Agilité"
 -- /rb sum stat fap
-L["Sum Feral Attack Power"] = "Cumul PA Farouche"
-L["Feral Attack Power <- Feral Attack Power Attack Power, Strength, Agility"] = "PA Farouche <- PA Farouche, PA, Force, Agi"
+L["Sum Feral Attack Power"] = "PA farouche"
+L["Feral Attack Power <- Feral Attack Power, Attack Power, Strength, Agility"] = "Total Puissance d'attaque farouche = Puissance d'attaque farouche + Puissance d'attaque + Force + Agilité"
 -- /rb sum stat dmg
-L["Sum Spell Damage"] = "Cumul Dégats des Sorts"
-L["Spell Damage <- Spell Damage Intellect, Spirit, Stamina"] = "Dégats des Sorts <- Dégats des Sorts, Intel, Esprit, Endu"
+L["Sum Spell Damage"] = "Puissance des sorts"
+L["Spell Damage <- Spell Damage, Intellect, Spirit, Stamina"] = "Total Puissance des sorts = Puissance des sorts + Intelligence + Esprit + Endurance"
 -- /rb sum stat dmgholy
-L["Sum Holy Spell Damage"] = "Cumul DS Sacré"
-L["Holy Spell Damage <- Holy Spell Damage Spell Damage, Intellect, Spirit"] = "DS Sacré <- DS Sacré, DS, Intel, Esprit"
+L["Sum Holy Spell Damage"] = "Puissance : sacré"
+L["Holy Spell Damage <- Holy Spell Damage, Spell Damage, Intellect, Spirit"] = "Total Puissance : sacré = Puissance : sacré + Puissance des sorts + Intelligence + Esprit"
 -- /rb sum stat dmgarcane
-L["Sum Arcane Spell Damage"] = "Cumul DS Arcane"
-L["Arcane Spell Damage <- Arcane Spell Damage Spell Damage, Intellect"] = "DS Arcane <- DS Arcane, DS, Intel"
+L["Sum Arcane Spell Damage"] = "Puissance : arcanes"
+L["Arcane Spell Damage <- Arcane Spell Damage, Spell Damage, Intellect"] = "Total Puissance : arcanes = Puissance : arcanes + Puissance des sorts + Intelligence"
 -- /rb sum stat dmgfire
-L["Sum Fire Spell Damage"] = "Cumul DS Feu"
-L["Fire Spell Damage <- Fire Spell Damage Spell Damage, Intellect, Stamina"] = "DS Feu <- DS Feu, DS, Intel, Endu"
+L["Sum Fire Spell Damage"] = "Puissance : feu"
+L["Fire Spell Damage <- Fire Spell Damage, Spell Damage, Intellect, Stamina"] = "Total Puissance : feu = Puissance : feu + Puissance des sorts + Intelligence + Endurance"
 -- /rb sum stat dmgnature
-L["Sum Nature Spell Damage"] = "Cumul DS Nature"
-L["Nature Spell Damage <- Nature Spell Damage Spell Damage, Intellect"] = "DS Nature <- DS Nature, DS, Intel"
+L["Sum Nature Spell Damage"] = "Puissance : nature"
+L["Nature Spell Damage <- Nature Spell Damage, Spell Damage, Intellect"] = "Total Puissance : nature = Puissance : nature + Puissance des sorts + Intelligence"
 -- /rb sum stat dmgfrost
-L["Sum Frost Spell Damage"] = "Cumul DS Givre"
-L["Frost Spell Damage <- Frost Spell Damage Spell Damage, Intellect"] = "DS Givre <- DS Givre, DS, Intel"
+L["Sum Frost Spell Damage"] = "Puissance : givre"
+L["Frost Spell Damage <- Frost Spell Damage, Spell Damage, Intellect"] = "Total Puissance : givre = Puissance : givre + Puissance des sorts + Intelligence"
 -- /rb sum stat dmgshadow
-L["Sum Shadow Spell Damage"] = "Cumul DS Ombre"
-L["Shadow Spell Damage <- Shadow Spell Damage Spell Damage, Intellect, Spirit, Stamina"] = "DS Ombre <- DS Ombre, DS, Intel, Esprit, Endu"
+L["Sum Shadow Spell Damage"] = "Puissance : ombre"
+L["Shadow Spell Damage <- Shadow Spell Damage, Spell Damage, Intellect, Spirit, Stamina"] = "Total Puissance : Ombre = Puissance : Ombre + Puissance des sorts + Intelligence + Esprit + Endurance"
 -- /rb sum stat heal
-L["Sum Healing"] = "Cumul Soins"
-L["Healing <- Healing Intellect, Spirit, Agility, Strength"] = "Soins <- Soins, Intel, Esprit, Agi, Force"
+L["Sum Healing"] = "Puissance des soins"
+L["Healing <- Healing, Intellect, Spirit, Agility, Strength"] = "Total Puissance des soins = Puissance des soins + Intelligence + Esprit + Agilité + Force"
 -- /rb sum stat hit
-L["Sum Hit Chance"] = "Cumul Toucher"
-L["Hit Chance <- Hit Rating Weapon Skill Rating"] = "Toucher <- Toucher, Score Arme"
--- /rb sum stat hitspell
-L["Sum Spell Hit Chance"] = "Cumul Toucher des Sorts"
-L["Spell Hit Chance <- Spell Hit Rating"] = "Toucher des Sorts <- Toucher des Sorts"
+L["Sum Hit Chance"] = "Toucher"
+L["Hit Chance <- Hit Rating, Weapon Skill Rating"] = "Total Toucher = Score de toucher + Compétence d'arme"
 -- /rb sum stat crit
-L["Sum Crit Chance"] = "Cumul Crit"
-L["Crit Chance <- Crit Rating Agility, Weapon Skill Rating"] = "Crit <- %Crit, Agi, Comp Arme"
+L["Sum Crit Chance"] = "Critique"
+L["Crit Chance <- Crit Rating, Agility, Weapon Skill Rating"] = "Total Coups critiques = Score de critique + Agilité + Compétence d'arme"
+-- /rb sum stat haste
+L["Sum Haste"] = "Hâte"
+L["Haste <- Haste Rating"] = "Total Hâte = Score de hâte"
 -- /rb sum stat critspell
-L["Sum Spell Crit Chance"] = "Cumul Crit Sorts"
-L["Spell Crit Chance <- Spell Crit Rating Intellect"] = "Crit Sorts <- %Crit Sorts, Intel"
+L["Sum Spell Crit Chance"] = "Critique des sorts"
+L["Spell Crit Chance <- Spell Crit Rating, Intellect"] = "Total Coups critiques des sorts = Score de critique des sorts + Intelligence"
+-- /rb sum stat hitspell
+L["Sum Spell Hit Chance"] = "Toucher des sorts"
+L["Spell Hit Chance <- Spell Hit Rating"] = "Total Toucher des Sorts = Score de toucher des sorts"
+-- /rb sum stat hastespell
+L["Sum Spell Haste"] = "Hâte des sorts"
+L["Spell Haste <- Spell Haste Rating"] = "Total Hâte des sorts = Score de hâte des sorts"
 -- /rb sum stat mp5
-L["Sum Mana Regen"] = "Cumul Regen Mana"
-L["Mana Regen <- Mana Regen Spirit"] = "Regen Mana <- Regen Mana, Esprit"
+L["Sum Mana Regen"] = "Mp5"
+L["Mana Regen <- Mana Regen, Spirit"] = "Total Régénération de mana = Régénération de mana + Esprit"
 -- /rb sum stat mp5nc
-L["Sum Mana Regen while not casting"] = "Cumul Regen Mana HI"
-L["Mana Regen while not casting <- Spirit"] = "Regen Mana HI <- Esprit"
+L["Sum Mana Regen while not casting"] = "Mp5 (repos)"
+L["Mana Regen while not casting <- Spirit"] = "Total Régénération de mana hors incantation = Esprit"
 -- /rb sum stat hp5
-L["Sum Health Regen"] = "Cumul Regen Vie"
-L["Health Regen <- Health Regen"] = "Regen Vie <- Regen Vie"
+L["Sum Health Regen"] = "Hp5"
+L["Health Regen <- Health Regen"] = "Total Régénération de santé = Régénération de santé"
 -- /rb sum stat hp5oc
-L["Sum Health Regen when out of combat"] = "Cumul Regen Vie HC"
-L["Health Regen when out of combat <- Spirit"] = "Regen Vie HC <- Esprit"
+L["Sum Health Regen when out of combat"] = "Hp5 (repos)"
+L["Health Regen when out of combat <- Spirit"] = "Total Régénération de santé hors combat = Régénération de santé + Esprit"
 -- /rb sum stat armor
-L["Sum Armor"] = "Cumul Armure"
-L["Armor <- Armor from items Armor from bonuses, Agility, Intellect"] = "Armure <- Armure Objets, Armure Bonus, Agi, Intel"
+L["Sum Armor"] = "Armure"
+L["Armor <- Armor from items, Armor from bonuses, Agility, Intellect"] = "Total Armure = Armure des objets + Armure bonus + Agilité + Intelligence"
 -- /rb sum stat blockvalue
-L["Sum Block Value"] = "Cumul Dégats Bloqués"
-L["Block Value <- Block Value Strength"] = "Dégats Bloqués <- Dégats Bloqués, Force"
+L["Sum Block Value"] = "Valeur de blocage"
+L["Block Value <- Block Value, Strength"] = "Total Valeur de blocage = Valeur de blocage + Force"
 -- /rb sum stat dodge
-L["Sum Dodge Chance"] = "Cumul Esquive"
-L["Dodge Chance <- Dodge Rating Agility, Defense Rating"] = "Esquive <- Score Esquive, Agi, Score Def"
+L["Sum Dodge Chance"] = "Esquive"
+L["Dodge Chance <- Dodge Rating, Agility, Defense Rating"] = "Total Esquive = Score d'esquive + Agilité + Score de défense"
 -- /rb sum stat parry
-L["Sum Parry Chance"] = "Cumul Parade"
-L["Parry Chance <- Parry Rating Defense Rating"] = "Parade <- Score Parade, Score Def"
+L["Sum Parry Chance"] = "Parade"
+L["Parry Chance <- Parry Rating, Defense Rating"] = "Total Parade = Score de parade + Score de défense"
 -- /rb sum stat block
-L["Sum Block Chance"] = "Cumul Bloquage"
-L["Block Chance <- Block Rating Defense Rating"] = "Bloquage <- Score Bloquage, Score Def"
+L["Sum Block Chance"] = "Chance de blocage"
+L["Block Chance <- Block Rating, Defense Rating"] = "Total Chance de blocage = Score de blocage + Score de défense"
 -- /rb sum stat avoidhit
-L["Sum Hit Avoidance"] = "Cumul Raté"
-L["Hit Avoidance <- Defense Rating"] = "Raté <- Score Def"
+L["Sum Hit Avoidance"] = "Raté"
+L["Hit Avoidance <- Defense Rating"] = "Total Raté = Score de défense"
 -- /rb sum stat avoidcrit
-L["Sum Crit Avoidance"] = "Cumul Def Crit"
-L["Crit Avoidance <- Defense Rating Resilience"] = "Def Crit <- Score Def, Resilience"
+L["Sum Crit Avoidance"] = "Réduction Critique"
+L["Crit Avoidance <- Defense Rating, Resilience"] = "Total Réduction des Coups critiques = Score de défense + Résilience"
 -- /rb sum stat neglectdodge
-L["Sum Dodge Neglect"] = "Cumul Ignore Esquive"
---["Dodge Neglect <- Weapon Skill Rating"] = "Ignore Esquive <- Score Arme",
+L["Sum Dodge Neglect"] = "Réduction Esquive"
+L["Dodge Neglect <- Expertise, Weapon Skill Rating"] = "Total Réduction d'esquive = Expertise + Compétence d'arme"
 -- /rb sum stat neglectparry
-L["Sum Parry Neglect"] = "Cumul Ignore Parade"
---["Parry Neglect <- Weapon Skill Rating"] = "Ignore Parade <- Score Arme",
+L["Sum Parry Neglect"] = "Réduction Parade"
+L["Parry Neglect <- Expertise, Weapon Skill Rating"] = "Total Réduction de parade = Expertise + Compétence d'arme"
 -- /rb sum stat neglectblock
-L["Sum Block Neglect"] = "Cumul Ignore Bloquage"
-L["Block Neglect <- Weapon Skill Rating"] = "Ignore Bloquage <- Score Arme"
+L["Sum Block Neglect"] = "Réduction Blocage"
+L["Block Neglect <- Weapon Skill Rating"] = "Total Réduction de blocage = Compétence d'arme"
 -- /rb sum stat resarcane
-L["Sum Arcane Resistance"] = "Cumul RA"
-L["Arcane Resistance Summary"] = "Résumé de la RA"
+L["Sum Arcane Resistance"] = "Résistance : arcanes"
+L["Arcane Resistance Summary"] = "Inclure la Résistance aux arcanes."
 -- /rb sum stat resfire
-L["Sum Fire Resistance"] = "Cumul RF"
-L["Fire Resistance Summary"] = "Résumé de la Rf"
+L["Sum Fire Resistance"] = "Résistance : feu"
+L["Fire Resistance Summary"] = "Inclure la Résistance au feu."
 -- /rb sum stat resnature
-L["Sum Nature Resistance"] = "Cumul RN"
-L["Nature Resistance Summary"] = "Résumé de la RN"
+L["Sum Nature Resistance"] = "Résistance : nature"
+L["Nature Resistance Summary"] = "Inclure la Résistance à la nature."
 -- /rb sum stat resfrost
-L["Sum Frost Resistance"] = "Cumul RG"
-L["Frost Resistance Summary"] = "Résumé de la RG"
+L["Sum Frost Resistance"] = "Résistance : givre"
+L["Frost Resistance Summary"] = "Inclure la Résistance au givre."
 -- /rb sum stat resshadow
-L["Sum Shadow Resistance"] = "Cumul RO"
-L["Shadow Resistance Summary"] = "Résumé de la RO"
+L["Sum Shadow Resistance"] = "Résistance : ombre"
+L["Shadow Resistance Summary"] = "Inclure la Résistance à l'ombre."
 -- /rb sum stat maxdamage
-L["Sum Weapon Max Damage"] = "Cumul Dommage Arme Max"
-L["Weapon Max Damage Summary"] = "Résumé du Dommage ax de l'Arme"
+L["Sum Weapon Max Damage"] = "Dégâts des armes"
+L["Weapon Max Damage Summary"] = "Inclure les dégâts des armes."
+-- /rb sum stat pen
+L["Sum Penetration"] = "Pénétration des sorts"
+L["Spell Penetration Summary"] = "Inclure la Pénétration des sorts."
+-- /rb sum stat ignorearmor
+L["Sum Ignore Armor"] = "Pénétration d'armure"
+L["Ignore Armor Summary"] = "Inclure la Pénétration d'armure."
 -- /rb sum stat weapondps
 --["Sum Weapon DPS"] = true,
 --["Weapon DPS Summary"] = true,
--- /rb sum statcomp
---["Stat - Composite"] = "Stats - Composées",
---["Choose composite stats for summary"] = "Choisir les Stats composées du résumé",
 -- /rb sum statcomp str
-L["Sum Strength"] = "Cumul Force"
-L["Strength Summary"] = "Résumé de la Force"
--- /rb sum statcomp agi
-L["Sum Agility"] = "Cumul Agi"
-L["Agility Summary"] = "Résumé de l'Agilité"
+L["Sum Strength"] = "Force"
+L["Strength Summary"] = "Inclure la  Force."
+-- /rb sum statcomp Agilité
+L["Sum Agility"] = "Agilité"
+L["Agility Summary"] = "Inclure l'Agilité."
 -- /rb sum statcomp sta
-L["Sum Stamina"] = "Cumul Endu"
-L["Stamina Summary"] = "Résumé de l'Endurance"
+L["Sum Stamina"] = "Endurance"
+L["Stamina Summary"] = "Inclure l'Endurance."
 -- /rb sum statcomp int
-L["Sum Intellect"] = "Cumul Int"
-L["Intellect Summary"] = "Résumé de l'Intelligence"
+L["Sum Intellect"] = "Intelligence"
+L["Intellect Summary"] = "Inclure l'Intelligence."
 -- /rb sum statcomp spi
-L["Sum Spirit"] = "Cumul Esprit"
-L["Spirit Summary"] = "Résumé de l'Esprit"
+L["Sum Spirit"] = "Esprit"
+L["Spirit Summary"] = "Inclure l'Esprit."
+-- /rb sum statcomp hitrating
+L["Sum Hit Rating"] = "Score de toucher"
+L["Hit Rating Summary"] = "Inclure le Score de toucher."
+-- /rb sum statcomp critrating
+L["Sum Crit Rating"] = "Score de critique"
+L["Crit Rating Summary"] = "Inclure le Score de critique."
+-- /rb sum statcomp hasterating
+L["Sum Haste Rating"] = "Score de hâte"
+L["Haste Rating Summary"] = "Inclure le Score de hâte."
+-- /rb sum statcomp hitspellrating
+L["Sum Spell Hit Rating"] = "Score de toucher des sorts"
+L["Spell Hit Rating Summary"] = "Inclure le Score de toucher des sorts."
+-- /rb sum statcomp critspellrating
+L["Sum Spell Crit Rating"] = "Score de critique des sorts"
+L["Spell Crit Rating Summary"] = "Inclure le Score de critique des sorts."
+-- /rb sum statcomp hastespellrating
+L["Sum Spell Haste Rating"] = "Score de hâte des sorts"
+L["Spell Haste Rating Summary"] = "Inclure le Score de hâte des sorts."
+-- /rb sum statcomp dodgerating
+L["Sum Dodge Rating"] = "Score d'esquive"
+L["Dodge Rating Summary"] = "Inclure le Score d'esquive."
+-- /rb sum statcomp parryrating
+L["Sum Parry Rating"] = "Score de parade"
+L["Parry Rating Summary"] = "Inclure le Score de parade."
+-- /rb sum statcomp blockrating
+L["Sum Block Rating"] = "Score de blocage"
+L["Block Rating Summary"] = "Inclure le Score de blocage."
+-- /rb sum statcomp res
+L["Sum Resilience"] = "Score de résilience"
+L["Resilience Summary"] = "Inclure le Score de résilience."
 -- /rb sum statcomp def
-L["Sum Defense"] = "Cumul Def"
-L["Defense <- Defense Rating"] = "Def <- Score def"
+L["Sum Defense"] = "Défense"
+L["Defense <- Defense Rating"] = "Défense = Score de défense"
 -- /rb sum statcomp wpn
-L["Sum Weapon Skill"] = "Cumul Comp Arme"
-L["Weapon Skill <- Weapon Skill Rating"] = "Comp Arme <- Score Arme"
-
+L["Sum Weapon Skill"] = "Compétence d'arme"
+L["Weapon Skill <- Weapon Skill Rating"] = "Compétence d'arme = Score de compétence d'arme"
+-- /rb sum statcomp exp -- 2.3.0
+L["Sum Expertise"] = "Expertise"
+L["Expertise <- Expertise Rating"] = "Total Expertise = Score d'expertise"
+-- /rb sum statcomp tp
+L["Sum TankPoints"] = "TankPoints"
+L["TankPoints <- Health, Total Reduction"] = "TankPoints = Vie + Réduction totale"
+-- /rb sum statcomp tr
+L["Sum Total Reduction"] = "Réduction complète"
+L["Total Reduction <- Armor, Dodge, Parry, Block, Block Value, Defense, Resilience, MobMiss, MobCrit, MobCrush, DamageTakenMods"] = "Total Réduction complète = Armure + Equive + Parade + Blocage + Valeur de blocage + Défense + Résilience + MobMiss, MobCrit, MobCrush, DamageTakenMods"
+-- /rb sum statcomp avoid
+L["Sum Avoidance"] = "Avoidance"
+L["Avoidance <- Dodge, Parry, MobMiss, Block(Optional)"] = "Total Avoidance = Esquive + Parade + Raté + Blocage(optionnel)"
 -- /rb sum gem
---["Gems"] = true,
---["Auto fill empty gem slots"] = true,
+L["Gems"] = "Gemmes"
+L["Auto fill empty gem slots"] = "Remplir automatiquement les châsses."
 -- /rb sum gem red
 L["Red Socket"] = EMPTY_SOCKET_RED
---["ItemID or Link of the gem you would like to auto fill"] = true,
+L["ItemID or Link of the gem you would like to auto fill"] = "ID ou lien (maj+clic) de la gemme que vous voudriez utliser."
 --["<ItemID|Link>"] = true,
---["%s is now set to %s"] = true,
---["Queried server for Gem: %s. Try again in 5 secs."] = true,
+L["%s is now set to %s"] = "%s supposera désormais %s."
+L["Queried server for Gem: %s. Try again in 5 secs."] = "Requête serveur pour : %s. Rééssayez dans 5 secondes."
 -- /rb sum gem yellow
 L["Yellow Socket"] = EMPTY_SOCKET_YELLOW
 -- /rb sum gem blue
@@ -369,16 +439,95 @@ L["ItemID: "] = "ID Objet : "
 -----------------------
 -- Matching Patterns --
 -----------------------
+-- Items to check --
+--------------------
+-- [Potent Ornate Topaz]
+-- +6 Spell Damage, +5 Spell Crit Rating
+--------------------
+-- ZG enchant
+-- +10 Defense Rating/+10 Stamina/+15 Block Value
+--------------------
+-- [Glinting Flam Spessarite]
+-- +3 Hit Rating and +3 Agility
+--------------------
+-- ItemID: 22589
+-- [Atiesh, Greatstaff of the Guardian] warlock version
+-- Equip: Increases the spell critical strike rating of all party members within 30 yards by 28.
+--------------------
+-- [Brilliant Wizard Oil]
+-- Use: While applied to target weapon it increases spell damage by up to 36 and increases spell critical strike rating by 14 . Lasts for 30 minutes. 
+----------------------------------------------------------------------------------------------------
+-- I redesigned the tooltip scanner using a more locale friendly, 2 pass matching matching algorithm.
+--
+-- The first pass searches for the rating number, the patterns are read from ["numberPatterns"] here,
+-- " by (%d+)" will match strings like: "Increases defense rating by 16."
+-- "%+(%d+)" will match strings like: "+10 Defense Rating"
+-- You can add additional patterns if needed, its not limited to 2 patterns.
+-- The separators are a table of strings used to break up a line into multiple lines what will be parsed seperately.
+-- For example "+3 Hit Rating, +5 Spell Crit Rating" will be split into "+3 Hit Rating" and " +5 Spell Crit Rating"
+--
+-- The second pass searches for the rating name, the names are read from ["statList"] here,
+-- It will look through the table in order, so you can put common strings at the begining to speed up the search,
+-- and longer strings should be listed first, like "spell critical strike" should be listed before "critical strike", 
+-- this way "spell critical strike" does get matched by "critical strike".
+-- Strings need to be in lower case letters, because string.lower is called on lookup
+--
+-- IMPORTANT: there may not exist a one-to-one correspondence, meaning you can't just translate this file, 
+-- but will need to go in game and find out what needs to be put in here.
+-- For example, in english I found 3 different strings that maps to CR_CRIT_MELEE: "critical strike", "critical hit" and "crit".
+-- You will need to find out every string that represents CR_CRIT_MELEE, and so on.
+-- In other languages there may be 5 different strings that should all map to CR_CRIT_MELEE.
+-- so please check in game that you have all strings, and not translate directly off this table.
+--
+-- Tip1: When doing localizations, I recommend you set debugging to true in RatingBuster.lua
+-- Find RatingBuster:SetDebugging(false) and change it to RatingBuster:SetDebugging(true)
+-- or you can type /rb debug to enable it in game
+--
+-- Tip2: The strings are passed into string.find, so you should escape the magic characters ^$()%.[]*+-? with a %
 L["numberPatterns"] = {
 	{pattern = " de (%d+)", addInfo = "AfterNumber",},
-	{pattern = "(%d+) \195\160 votre ", addInfo = "AfterNumber",},
 	{pattern = "([%+%-]%d+)", addInfo = "AfterStat",},
-	{pattern = "ajoute (%d+) (à|au)", addInfo = "AfterNumber",}, -- for "add xx stat" type pattern, ex: Adamantite Sharpening Stone
+	{pattern = "augmente.-(%d+)", addInfo = "AfterNumber",}, -- for "grant you xx stat" type pattern, ex: Quel'Serrar, Assassination Armor set
+	{pattern = "ajoute (%d+) (à|au))", addInfo = "AfterNumber",}, -- for "add xx stat" type pattern, ex: Adamantite Sharpening Stone
+	-- Added [^%%] so that it doesn't match strings like "Increases healing by up to 10% of your total Intellect." [Whitemend Pants] ID: 24261
+	-- Added [^|] so that it doesn't match enchant strings (JewelTips)
+	{pattern = "(%d+)([^%d%%|]+)", addInfo = "AfterStat",}, -- [發光的暗影卓奈石] +6法術傷害及5耐力
 }
 L["separators"] = {
-	"/", " et ", ",", "%. ",
+	"/", " et ", ",", "%. ", " pour ", "&", " : "
 }
-
+--[[ Rating ID
+CR_WEAPON_SKILL = 1;
+CR_DEFENSE_SKILL = 2;
+CR_DODGE = 3;
+CR_PARRY = 4;
+CR_BLOCK = 5;
+CR_HIT_MELEE = 6;
+CR_HIT_RANGED = 7;
+CR_HIT_SPELL = 8;
+CR_CRIT_MELEE = 9;
+CR_CRIT_RANGED = 10;
+CR_CRIT_SPELL = 11;
+CR_HIT_TAKEN_MELEE = 12;
+CR_HIT_TAKEN_RANGED = 13;
+CR_HIT_TAKEN_SPELL = 14;
+CR_CRIT_TAKEN_MELEE = 15;
+CR_CRIT_TAKEN_RANGED = 16;
+CR_CRIT_TAKEN_SPELL = 17;
+CR_HASTE_MELEE = 18;
+CR_HASTE_RANGED = 19;
+CR_HASTE_SPELL = 20;
+CR_WEAPON_SKILL_MAINHAND = 21;
+CR_WEAPON_SKILL_OFFHAND = 22;
+CR_WEAPON_SKILL_RANGED = 23;
+CR_EXPERTISE = 24;
+--
+SPELL_STAT1_NAME = "Strength"
+SPELL_STAT2_NAME = "Agility"
+SPELL_STAT3_NAME = "Stamina"
+SPELL_STAT4_NAME = "Intellect"
+SPELL_STAT5_NAME = "Spirit"
+--]]
 L["statList"] = {
 	{pattern = string.lower(SPELL_STAT1_NAME), id = SPELL_STAT1_NAME}, -- Strength
 	{pattern = string.lower(SPELL_STAT2_NAME), id = SPELL_STAT2_NAME}, -- Agility
@@ -386,42 +535,53 @@ L["statList"] = {
 	{pattern = string.lower(SPELL_STAT4_NAME), id = SPELL_STAT4_NAME}, -- Intellect
 	{pattern = string.lower(SPELL_STAT5_NAME), id = SPELL_STAT5_NAME}, -- Spirit
 	{pattern = "score de défense", id = CR_DEFENSE_SKILL},
+	{pattern = "score d’esquive", id = CR_DODGE},
 	{pattern = "score d'esquive", id = CR_DODGE},
-	{pattern = "score de blocage", id = CR_BLOCK}, -- block enchant: "+10 Shield Block Rating"
+	{pattern = "score de blocage", id = CR_BLOCK}, --Ench. de bouclier (Blocage inférieur)
+	{pattern = "score de Maîtrise du blocage", id = CR_BLOCK}, --Ench. de bouclier (Maîtrise du blocage)
 	{pattern = "score de parade", id = CR_PARRY},
 
 	{pattern = "score de critique des sorts", id = CR_CRIT_SPELL},
+	{pattern = "score de coup critique des sorts", id = CR_CRIT_SPELL},
+	{pattern = "score de toucher critique des sorts", id = CR_CRIT_SPELL},
+	{pattern = "score de critique à distance", id = CR_CRIT_RANGED},
 	{pattern = "score de coup critique à distance", id = CR_CRIT_RANGED},
+	{pattern = "score de toucher critique à distance", id = CR_CRIT_RANGED},
+	{pattern = "score de critique", id = CR_CRIT_MELEE}, --ex : https://fr.tbc.wowhead.com/item=30565/opale-de-feu-dassassin
 	{pattern = "score de coup critique", id = CR_CRIT_MELEE},
+	{pattern = "score de toucher critique", id = CR_CRIT_MELEE},
 
 	{pattern = "score de toucher des sorts", id = CR_HIT_SPELL},
 	{pattern = "score de toucher à distance", id = CR_HIT_RANGED},
 	{pattern = "score de toucher", id = CR_HIT_MELEE},
-
+	
 	{pattern = "résilience", id = CR_CRIT_TAKEN_MELEE}, -- resilience is implicitly a rating
-	{pattern = "score d'évitement des coups", id = CR_HIT_TAKEN_MELEE},
 
 	{pattern = "score de hâte des sorts", id = CR_HASTE_SPELL},
 	{pattern = "score de hâte à distance", id = CR_HASTE_RANGED},
 	{pattern = "score de hâte", id = CR_HASTE_MELEE},
-	{pattern = "scores de vitesse", id = CR_HASTE_MELEE}, -- [Tambours de Bataille]
+	{pattern = "score de hâte en mêlée", id = CR_HASTE_MELEE}, -- [Tambours de Bataille]
 
+	{pattern = "score d’expertise", id = CR_EXPERTISE},
+	{pattern = "score d'expertise", id = CR_EXPERTISE},
+	{pattern = "score d'évitement des coups", id = CR_HIT_TAKEN_MELEE},
 
-	{pattern = "score de la compétence dagues", id = CR_WEAPON_SKILL},
-	{pattern = "score de la compétence epées", id = CR_WEAPON_SKILL},
+	--[[
+	{pattern = "score de la compétence dagues", id = CR_WEAPON_SKILL}, {pattern = "Dagues augmentées", id = CR_WEAPON_SKILL},
+	{pattern = "score de la compétence epées", id = CR_WEAPON_SKILL}, {pattern = "Epées augmentées", id = CR_WEAPON_SKILL},
 	{pattern = "score de la compétence epées à deux mains", id = CR_WEAPON_SKILL},
 	{pattern = "score de la compétence haches", id = CR_WEAPON_SKILL},
-	{pattern = "score de la compétence haches à deux mains", id = CR_WEAPON_SKILL},
-	{pattern = "score de la compétence masses", id = CR_WEAPON_SKILL},
-	{pattern = "score de la compétence masses à deux mains", id = CR_WEAPON_SKILL},
-	{pattern = "score de la compétence armes d'hast", id = CR_WEAPON_SKILL},
 	{pattern = "score de la compétence arcs", id = CR_WEAPON_SKILL},
-	{pattern = "score de la compétence fusils", id = CR_WEAPON_SKILL},
 	{pattern = "score de la compétence arbalètes", id = CR_WEAPON_SKILL},
-	{pattern = "score de la compétence bâton", id = CR_WEAPON_SKILL},
-	{pattern = "score de la compétence mains nues", id = CR_WEAPON_SKILL},
-
-	--{pattern = "score de la compétence", id = CR_WEAPON_SKILL},
+	{pattern = "score de la compétence fusils", id = CR_WEAPON_SKILL},
+	{pattern = "score de la compétence combat farouche", id = CR_WEAPON_SKILL},
+	{pattern = "score de la compétence masses", id = CR_WEAPON_SKILL},
+	{pattern = "score de la compétence armes d'hast", id = CR_WEAPON_SKILL},
+	{pattern = "score de la compétence bâton", id = CR_WEAPON_SKILL},	
+	{pattern = "score de la compétence haches à deux mains", id = CR_WEAPON_SKILL},
+	{pattern = "score de la compétence masses à deux mains", id = CR_WEAPON_SKILL},
+	{pattern = "score de la compétence armes de pugilat", id = CR_WEAPON_SKILL},
+	--]]
 }
 -------------------------
 -- Added info patterns --
@@ -429,20 +589,24 @@ L["statList"] = {
 -- $value will be replaced with the number
 -- EX: "$value% Crit" -> "+1.34% Crit"
 -- EX: "Crit $value%" -> "Crit +1.34%"
-L["$value% Crit"] = "$value% Crit"
-L["$value% Spell Crit"] = "$value% Crit Sorts"
-L["$value% Dodge"] = "$value% Esquive"
+L["$value% Crit"] = "$value% CC"
+L["$value% Spell Crit"] = "$value% CC sorts"
+L["$value% Dodge"] = "$value% esquive"
 L["$value HP"] = "$value PV"
 L["$value MP"] = "$value PM"
 L["$value AP"] = "$value PA"
-L["$value RAP"] = "$value PA Dist"
-L["$value Dmg"] = "$value Dégats"
-L["$value Heal"] = "$value Soins"
-L["$value Armor"] = "$value Armure"
-L["$value Block"] = "$value Blocage"
-L["$value MP5"] = "$value Mana/5sec"
-L["$value MP5(NC)"] = "$value Mana/5sec(HI)"
-L["$value HP5"] = "$value Vie/5sec"
+L["$value RAP"] = "$value PA dist."
+L["$value Dmg"] = "$value dégâts"
+L["$value Heal"] = "$value soins"
+L["$value Armor"] = "$value armure"
+L["$value Block"] = "$value blocage"
+L["$value MP5"] = "$value Mp5"
+L["$value MP5(NC)"] = "$value Mp5(repos)"
+L["$value HP5"] = "$value Hp5"
+L["$value to be Dodged/Parried"] = "$value esquivé/paré"
+L["$value to be Crit"] = "$value recevoir CC"
+L["$value Crit Dmg Taken"] = "$value dégâts CC"
+L["$value DOT Dmg Taken"] = "$value dégâts DoT"
 
 ------------------
 -- Stat Summary --

--- a/locales/frFR.lua
+++ b/locales/frFR.lua
@@ -19,7 +19,7 @@ L["Options Window"] = "Fenêtre des options"
 L["Shows the Options Window"] = "Affiche la fenêtre des options"
 -- /rb statmod
 L["Enable Stat Mods"] = "Activer les Stat Mods"
-L["Enable support for Stat Mods"] = "Activer le support pour Stat Mods"
+L["Enable support for Stat Mods"] = "Active le support pour Stat Mods"
 -- /rb itemid
 L["Show ItemID"] = "ID des objets"
 L["Show the ItemID in tooltips"] = "Affiche l'ID des objets dans les info-bulles."
@@ -45,20 +45,20 @@ L["Enable colored text"] = "Active le texte coloré"
 L["Rating"] = "Détail des scores"
 L["Options for Rating display"] = "Sélectionne les différents bonus liés aux scores à inclure dans les info-bulles des objets."
 -- /rb rating show
-L["Show Rating conversions"] = "Aperçu conversion"
-L["Show Rating conversions in tooltips"] = "Ajoute la conversion des valeurs des différents scores dans les info-bulles des objets.\n\nCette case est requise pour l'affichage des scores détaillés."
+L["Show Rating conversions"] = "Aperçu pourcentage"
+L["Show Rating conversions in tooltips"] = "Ajoute la conversion en pourcentage des différents scores dans les info-bulles des objets.\n\nCette case est requise pour l'affichage des scores détaillés."
 -- /rb rating detail
 L["Show detailed conversions text"] = "Textes plus détaillés" 
-L["Show detailed text for Resiliance and Expertise conversions"] = "Rend la conversion des score de résilience et d'expertise plus précise.\n\nLa résilience indiquera le pourcentage d'évitement des coups critiques, réduction des dégâts critiques et réduction des dégâts périodiques.\n\nL'expertise indiquera le pourcentage de réduction du risque d'être esquivé et paré."
+L["Show detailed text for Resiliance and Expertise conversions"] = "Rend la conversion des score de résilience et d'expertise plus précise.\n\nLa résilience indiquera l'évitement des coups critiques, la diminution des dégâts critiques et la diminution des dégâts périodiques.\n\nL'expertise indiquera la diminution du risque d'être esquivé et paré."
 -- /rb rating def
 L["Defense breakdown"] = "Défense détaillée"
-L["Convert Defense into Crit Avoidance, Hit Avoidance, Dodge, Parry and Block"] = "Convertis le score de défense en pourcentage de chance d'esquive, parade, blocage, évitement des coups et évitement des coups critiques."
+L["Convert Defense into Crit Avoidance, Hit Avoidance, Dodge, Parry and Block"] = "Convertis le score de défense en esquive, parade, blocage, évitement des coups et évitement des coups critiques."
 -- /rb rating wpn
 L["Weapon Skill breakdown"] = "Comp. d'arme détaillée"
-L["Convert Weapon Skill into Crit, Hit, Dodge Neglect, Parry Neglect and Block Neglect"] = "Convertis le score de compétence d'arme en pourcentage de coups critiques, toucher, réduction d'esquive, réduction de parade et réduction de blocage."
+L["Convert Weapon Skill into Crit, Hit, Dodge Neglect, Parry Neglect and Block Neglect"] = "Convertis le score de compétence d'arme en coups critiques, toucher, diminution d'esquive, diminution de parade et diminution de blocage."
 -- /rb rating exp -- 2.3.0
 L["Expertise breakdown"] = "Expertise détaillée"
-L["Convert Expertise into Dodge Neglect and Parry Neglect"] = "Convertis le score d'expertise en un pourcentage de réduction d'esquive et de parade."
+L["Convert Expertise into Dodge Neglect and Parry Neglect"] = "Convertis le score d'expertise en diminution d'esquive et diminution de parade."
 
 -- /rb stat
 L["Stat Breakdown"] = "Détail des caractéristiques"
@@ -70,14 +70,14 @@ L["Show base stat conversions in tooltips"] = "Ajoute un aperçu détaillé des 
 L["Strength"] = "Force"
 L["Changes the display of Strength"] = "Sélectionne les différents bonus liés à la Force."
 -- /rb stat str ap
-L["Show Attack Power"] = "Puisance d'attaque"
+L["Show Attack Power"] = "Puissance d'attaque"
 L["Show Attack Power from Strength"] = "Affiche la Puissance d'attaque apportée par la Force."
 -- /rb stat str block
 L["Show Block Value"] = "Valeur de blocage"
 L["Show Block Value from Strength"] = "Affiche la Valeur de blocage apportée par la Force."
 -- /rb stat str dmg
 L["Show Spell Damage"] = "Dégâts des sorts"
-L["Show Spell Damage from Strength"] = "Affiche les Dégâts des sorts apportée par la Force."
+L["Show Spell Damage from Strength"] = "Affiche les Dégâts des sorts apportés par la Force."
 -- /rb stat str heal
 L["Show Healing"] = "Puissance des soins"
 L["Show Healing from Strength"] = "Affiche la Puissance des soins apportée par la Force."
@@ -86,16 +86,16 @@ L["Show Healing from Strength"] = "Affiche la Puissance des soins apportée par 
 L["Agility"] = "Agilité"
 L["Changes the display of Agility"] = "Sélectionne les différents bonus liés à l'Agilité."
 -- /rb stat Agilité crit
-L["Show Crit"] = "Critique (%)"
+L["Show Crit"] = "Critiques"
 L["Show Crit chance from Agility"] = "Affiche le pourcentage de Coups critiques apporté par l'Agilité."
 -- /rb stat Agilité dodge
-L["Show Dodge"] = "Esquive (%)"
+L["Show Dodge"] = "Esquive"
 L["Show Dodge chance from Agility"] = "Affiche le poucentage d'Esquive apporté par l'Agilité."
 -- /rb stat Agilité ap
 L["Show Attack Power"] = "Puissance d'attaque"
 L["Show Attack Power from Agility"] = "Affiche la Puissance d'attaque apportée par l'Agilité."
 -- /rb stat Agilité rap
-L["Show Ranged Attack Power"] = "PA à distance"
+L["Show Ranged Attack Power"] = "Puis. d'att. à distance"
 L["Show Ranged Attack Power from Agility"] = "Affiche la Puissance d'attaque à distance apportée par l'Agilité."
 -- /rb stat Agilité armor
 L["Show Armor"] = "Armure"
@@ -112,31 +112,31 @@ L["Show Health"] = "Points de vie"
 L["Show Health from Stamina"] = "Affiche les points de vie liés à l'Endurance."
 -- /rb stat sta dmg
 L["Show Spell Damage"] = "Dégâts des sorts"
-L["Show Spell Damage from Stamina"] = "Affiche les Dégâts des sorts apportée par l'Endurance."
+L["Show Spell Damage from Stamina"] = "Affiche les Dégâts des sorts apportés par l'Endurance."
 
 -- /rb stat int
 L["Intellect"] = "Intelligence"
 L["Changes the display of Intellect"] = "Sélectionne les différents bonus liés à l'Intelligence."
 -- /rb stat int spellcrit
-L["Show Spell Crit"] = "Critique des sorts (%)"
+L["Show Spell Crit"] = "Critiques des sorts"
 L["Show Spell Crit chance from Intellect"] = "Affiche le pourcentage de Coups critiques des sorts apporté par l'Intelligence."
 -- /rb stat int mp
 L["Show Mana"] = "Points de mana"
 L["Show Mana from Intellect"] = "Affiche les points de mana apportés par l'Intelligence."
 -- /rb stat int dmg
 L["Show Spell Damage"] = "Dégâts des sorts"
-L["Show Spell Damage from Intellect"] = "Affiche les Dégâts des sorts apportée par l'Intelligence."
+L["Show Spell Damage from Intellect"] = "Affiche les Dégâts des sorts apportés par l'Intelligence."
 -- /rb stat int heal
 L["Show Healing"] = "Puissance des soins"
 L["Show Healing from Intellect"] = "Affiche la Puissance des soins apportée par l'Intelligence."
 -- /rb stat int mp5
-L["Show Mana Regen"] = "Mp5 (incantation)"
-L["Show Mana Regen while casting from Intellect"] = "Affiche la Régénération de mana pendant l'incantation des sorts apportée par l'Intelligence."
+L["Show Mana Regen"] = "Régén. mana (incantation)"
+L["Show Mana Regen while casting from Intellect"] = "Affiche la Régén. mana pendant l'incantation des sorts apportée par l'Intelligence."
 -- /rb stat int mp5nc
-L["Show Mana Regen while NOT casting"] = "Affiche la Régénération de mana hors incantation."
-L["Show Mana Regen while NOT casting from Intellect"] = "Affiche la Régénération de mana hors incantation apportée par l'Intelligence."
+L["Show Mana Regen while NOT casting"] = "Affiche la Régén. mana hors incantation."
+L["Show Mana Regen while NOT casting from Intellect"] = "Affiche la Régén. mana hors incantation apportée par l'Intelligence."
 -- /rb stat int rap
-L["Show Ranged Attack Power"] = "PA à distance"
+L["Show Ranged Attack Power"] = "Puis. d'att. à distance"
 L["Show Ranged Attack Power from Intellect"] = "Affiche la Puissance d'attaque à distance apportée par l'Intelligence."
 -- /rb stat int armor
 L["Show Armor"] = "Armure"
@@ -146,39 +146,39 @@ L["Show Armor from Intellect"] = "Affiche l'Armure apportée par l'Intelligence.
 L["Spirit"] = "Esprit"
 L["Changes the display of Spirit"] = "Sélectionne les différents bonus liés à l'Esprit."
 -- /rb stat spi mp5
-L["Show Mana Regen"] = "Mp5 (incantation)"
-L["Show Mana Regen while casting from Spirit"] = "Affiche la Régénération de mana pendant l'incantation des sorts apportée par l'Esprit."
+L["Show Mana Regen"] = "Régén. mana (incantation)"
+L["Show Mana Regen while casting from Spirit"] = "Affiche la Régén. mana pendant l'incantation des sorts apportés par l'Esprit."
 -- /rb stat spi mp5nc
-L["Show Mana Regen while NOT casting"] = "Mp5 (repos)"
-L["Show Mana Regen while NOT casting from Spirit"] = "Affiche la Régénération de mana au hors incantation apportée par l'Esprit."
+L["Show Mana Regen while NOT casting"] = "Régén. mana (repos)"
+L["Show Mana Regen while NOT casting from Spirit"] = "Affiche la Régén. mana au hors incantation apportée par l'Esprit."
 -- /rb stat spi hp5
-L["Show Health Regen"] = "Hp5 (repos)"
-L["Show Health Regen from Spirit"] = "Affiche la Régénération de santé hors combat apportée par l'Esprit."
+L["Show Health Regen"] = "Régén. vie (repos)"
+L["Show Health Regen from Spirit"] = "Affiche la Régén. vie hors combat apportée par l'Esprit."
 -- /rb stat spi dmg
 L["Show Spell Damage"] = "Dégâts des sorts"
-L["Show Spell Damage from Spirit"] = "Affiche les Dégâts des sorts apportée par l'Esprit."
+L["Show Spell Damage from Spirit"] = "Affiche les Dégâts des sorts apportés par l'Esprit."
 -- /rb stat spi heal
 L["Show Healing"] = "Puissance des soins"
 L["Show Healing from Spirit"] = "Affiche la Puissance des soins apportée par l'Esprit."
 
 -- /rb sum
 L["Stat Summary"] = "Résumé des Stats"
-L["Options for stat summary"] = "Le résumé des différents bonus cumulés apportés par les statistiques peut être inclu dans les info-bulles des objets."
+L["Options for stat summary"] = "Un résumé des différents bonus apportés par les statistiques peut être inclu dans les info-bulles des objets."
 -- /rb sum show
 L["Show stat summary"] = "Afficher le résumé"
-L["Show stat summary in tooltips"] = "Ajoute le résumé de tous les bonus provenant des différentes statistiques dans les info-bulles des objets."
+L["Show stat summary in tooltips"] = "Ajoute un résumé de tous les bonus provenant des différentes statistiques dans les info-bulles des objets."
 -- /rb sum ignore
 L["Ignore settings"] = "Valeurs à ignorer"
 L["Ignore stuff when calculating the stat summary"] = "Sélectionne les valeurs à ignorer lors des calculs du résumé."
 -- /rb sum ignore unused
-L["Ignore unused items types"] = "Types d'objets non utilisables"
-L["Show stat summary only for highest level armor type and items you can use with uncommon quality and up"] = "N'affiche le résumé que sur les types d'armes et d'armures que votre classe peut utiliser et pour les équipements de qualité au moins Inhabituelle."
+L["Ignore unused items types"] = "Objets non utilisables"
+L["Show stat summary only for highest level armor type and items you can use with uncommon quality and up"] = "Ne pas afficher le résumé pour les objets que votre classe ne peut pas utiliser et pour les équipements de qualité inférieure à Inhabituelle."
 -- /rb sum ignore equipped
 L["Ignore equipped items"] = "Objets équipés"
 L["Hide stat summary for equipped items"] = "Ne pas afficher le résumé pour les objets équipés."
 -- /rb sum ignore enchant
 L["Ignore enchants"] = "Enchantements"
-L["Ignore enchants on items when calculating the stat summary"] = "Ignorer les bonus d'enchantement lors des calculs du résumé."
+L["Ignore enchants on items when calculating the stat summary"] = "Ignorer les bonus des enchantements lors des calculs du résumé."
 -- /rb sum ignore gem
 L["Ignore gems"] = "Gemmes"
 L["Ignore gems on items when calculating the stat summary"] = "Ignorer les bonus des gemmes lors des calculs du résumé."
@@ -202,10 +202,10 @@ L["Show title text"] = "AJouter le titre"
 L["Show the title text before summary listing"] = "Ajoute le titre avant le résumé."
 -- /rb sum showzerostat
 L["Show zero value stats"] = "Ajouter les stats nulles"
-L["Show zero value stats in summary for consistancy"] = "Ajoute les stats nulles/absentes au résumé pour plus de cohérence."
+L["Show zero value stats in summary for consistancy"] = "Ajoute les stats nulles/absentes de l'objet au résumé."
 -- /rb sum calcsum
 L["Calculate stat sum"] = "Afficher les totaux"
-L["Calculate the total stats for the item"] = "Calcule et affiche le montant final de chaque statistique présente sur les objets."
+L["Calculate the total stats for the item"] = "Calcule et affiche le montant cumulé de chaque statistique présente sur les objets."
 -- /rb sum calcdiff
 L["Calculate stat diff"] = "Comparaison"
 L["Calculate the stat difference for the item and equipped items"] = "Ajoute une comparaison entre les statistiques des objets et celles de l'équipement actuel."
@@ -217,130 +217,130 @@ L["Include block chance in Avoidance summary"] = "Blocage dans Évitement"
 L["Enable to include block chance in Avoidance summary, Disable for only dodge, parry, miss"] = "Inclue les chances de blocage au résumé Évitement, en plus de l'esquive, de la parade et du raté.\n\nUtile pour les spécialisations tank disposant d'un bouclier."
 -- /rb sum basic
 L["Stat - Basic"] = "Stats - Basiques"
-L["Choose basic stats for summary"] = "Sélectionne les différentes caractéristiques basiques à prendre en compte lors des calculs du résumé."
+L["Choose basic stats for summary"] = "Sélectionne les différentes caractéristiques basiques à inclure au résumé."
 -- /rb sum physical
 L["Stat - Physical"] = "Stats - Physiques"
-L["Choose physical damage stats for summary"] = "Sélectionne les différentes caractéristiques de combat physique à prendre en compte lors des calculs du résumé."
+L["Choose physical damage stats for summary"] = "Sélectionne les différentes caractéristiques de combat physique à inclure au résumé."
 -- /rb sum spell
 L["Stat - Spell"] = "Stats - Magiques"
-L["Choose spell damage and healing stats for summary"] = "Sélectionne les différentes caractéristiques de combat magique à prendre en compte lors des calculs du résumé."
+L["Choose spell damage and healing stats for summary"] = "Sélectionne les différentes caractéristiques de combat magique à inclure au résumé."
 -- /rb sum tank
 L["Stat - Tank"] = "Stats - Tank"
-L["Choose tank stats for summary"] = "Sélectionne les différentes caractéristiques défensives à prendre en compte lors des calculs du résumé."
+L["Choose tank stats for summary"] = "Sélectionne les différentes caractéristiques défensives à inclure au résumé."
 -- /rb sum stat hp
-L["Sum Health"] = "Vie"
-L["Health <- Health, Stamina"] = "Total Vie = Vie + Endurance"
+L["Sum Health"] = "Points de vie"
+L["Health <- Health, Stamina"] = "Inclure les Points de vie conférés par : Points de vie, Endurance."
 -- /rb sum stat mp
-L["Sum Mana"] = "Mana"
-L["Mana <- Mana, Intellect"] = "Total Mana = Mana + Intelligence"
+L["Sum Mana"] = "Points de mana"
+L["Mana <- Mana, Intellect"] = "Inclure les Points de mana conférés par : Points de mana, Intelligence."
 -- /rb sum stat ap
 L["Sum Attack Power"] = "Puissance d'attaque"
-L["Attack Power <- Attack Power, Strength, Agility"] = "Total Puissance d'attaque = Puissance d'attaque + Force + Agilité"
+L["Attack Power <- Attack Power, Strength, Agility"] = "Inclure la Puissance d'attaque conférée par : Puissance d'attaque, Force, Agilité."
 -- /rb sum stat rap
-L["Sum Ranged Attack Power"] = "PA à distance"
-L["Ranged Attack Power <- Ranged Attack Power, Intellect, Attack Power, Strength, Agility"] = "Total Puissance d'attaque à distance = Puissance d'attaque à distance + Intelligence + Puissance d'attaque + Force + Agilité"
+L["Sum Ranged Attack Power"] = "Puis. d'att. à distance"
+L["Ranged Attack Power <- Ranged Attack Power, Intellect, Attack Power, Strength, Agility"] = "Inclure la Puissance d'attaque à distance conférée par : Puissance d'attaque à distance, Intelligence, Puissance d'attaque, Force, Agilité."
 -- /rb sum stat fap
-L["Sum Feral Attack Power"] = "PA farouche"
-L["Feral Attack Power <- Feral Attack Power, Attack Power, Strength, Agility"] = "Total Puissance d'attaque farouche = Puissance d'attaque farouche + Puissance d'attaque + Force + Agilité"
+L["Sum Feral Attack Power"] = "Puis. d'att. farouche"
+L["Feral Attack Power <- Feral Attack Power, Attack Power, Strength, Agility"] = "Inclure la Puissance d'attaque farouche conférée par : Puissance d'attaque farouche, Puissance d'attaque, Force, Agilité."
 -- /rb sum stat dmg
 L["Sum Spell Damage"] = "Dégâts des sorts"
-L["Spell Damage <- Spell Damage, Intellect, Spirit, Stamina"] = "Total Dégâts des sorts = Dégâts des sorts + Intelligence + Esprit + Endurance"
+L["Spell Damage <- Spell Damage, Intellect, Spirit, Stamina"] = "Inclure les Dégâts des sorts conférés par : Dégâts des sorts, Intelligence, Esprit, Endurance."
 -- /rb sum stat dmgholy
-L["Sum Holy Spell Damage"] = "Dégâts : sacré"
-L["Holy Spell Damage <- Holy Spell Damage, Spell Damage, Intellect, Spirit"] = "Total Dégâts : sacré = Dégâts : sacré + Dégâts des sorts + Intelligence + Esprit"
+L["Sum Holy Spell Damage"] = "Dégâts : Sacré"
+L["Holy Spell Damage <- Holy Spell Damage, Spell Damage, Intellect, Spirit"] = "Inclure les Dégâts du Sacré conférés par : Dégâts du Sacré, Dégâts des sorts, Intelligence, Esprit."
 -- /rb sum stat dmgarcane
-L["Sum Arcane Spell Damage"] = "Dégâts : arcanes"
-L["Arcane Spell Damage <- Arcane Spell Damage, Spell Damage, Intellect"] = "Total Dégâts : arcanes = Dégâts : arcanes + Dégâts des sorts + Intelligence"
+L["Sum Arcane Spell Damage"] = "Dégâts : Arcanes"
+L["Arcane Spell Damage <- Arcane Spell Damage, Spell Damage, Intellect"] = "Inclure les Dégâts des Arcanes conférés par : Dégâts des Arcanes, Dégâts des sorts, Intelligence."
 -- /rb sum stat dmgfire
-L["Sum Fire Spell Damage"] = "Dégâts : feu"
-L["Fire Spell Damage <- Fire Spell Damage, Spell Damage, Intellect, Stamina"] = "Total Dégâts : feu = Dégâts : feu + Dégâts des sorts + Intelligence + Endurance"
+L["Sum Fire Spell Damage"] = "Dégâts : Feu"
+L["Fire Spell Damage <- Fire Spell Damage, Spell Damage, Intellect, Stamina"] = "Inclure les Dégâts de Feu conférés par : Dégâts de Feu, Dégâts des sorts, Intelligence, Endurance."
 -- /rb sum stat dmgnature
-L["Sum Nature Spell Damage"] = "Dégâts : nature"
-L["Nature Spell Damage <- Nature Spell Damage, Spell Damage, Intellect"] = "Total Dégâts : nature = Dégâts : nature + Dégâts des sorts + Intelligence"
+L["Sum Nature Spell Damage"] = "Dégâts : Nature"
+L["Nature Spell Damage <- Nature Spell Damage, Spell Damage, Intellect"] = "Inclure les Dégâts de Nature conférés par : Dégâts de Nature, Dégâts des sorts, Intelligence."
 -- /rb sum stat dmgfrost
-L["Sum Frost Spell Damage"] = "Dégâts : givre"
-L["Frost Spell Damage <- Frost Spell Damage, Spell Damage, Intellect"] = "Total Dégâts : givre = Dégâts : givre + Dégâts des sorts + Intelligence"
+L["Sum Frost Spell Damage"] = "Dégâts : Givre"
+L["Frost Spell Damage <- Frost Spell Damage, Spell Damage, Intellect"] = "Inclure les Dégâts de Givre conférés par : Dégâts de Givre, Dégâts des sorts, Intelligence."
 -- /rb sum stat dmgshadow
-L["Sum Shadow Spell Damage"] = "Dégâts : ombre"
-L["Shadow Spell Damage <- Shadow Spell Damage, Spell Damage, Intellect, Spirit, Stamina"] = "Total Dégâts : Ombre = Dégâts : Ombre + Dégâts des sorts + Intelligence + Esprit + Endurance"
+L["Sum Shadow Spell Damage"] = "Dégâts : Ombre"
+L["Shadow Spell Damage <- Shadow Spell Damage, Spell Damage, Intellect, Spirit, Stamina"] = "Inclure les Dégâts d'Ombre conférés par : Dégâts d'Ombre, Dégâts des sorts, Intelligence, Esprit, Endurance."
 -- /rb sum stat heal
 L["Sum Healing"] = "Puissance des soins"
-L["Healing <- Healing, Intellect, Spirit, Agility, Strength"] = "Total Puissance des soins = Puissance des soins + Intelligence + Esprit + Agilité + Force"
+L["Healing <- Healing, Intellect, Spirit, Agility, Strength"] = "Inclure la Puissance des soins conférée par : Puissance des soins, Intelligence, Esprit, Agilité, Force."
 -- /rb sum stat hit
 L["Sum Hit Chance"] = "Toucher"
-L["Hit Chance <- Hit Rating, Weapon Skill Rating"] = "Total Toucher = Score de toucher + Compétence d'arme"
+L["Hit Chance <- Hit Rating, Weapon Skill Rating"] = "Inclure le Toucher conféré par : Score de toucher, Compétence d'arme."
 -- /rb sum stat crit
-L["Sum Crit Chance"] = "Critique"
-L["Crit Chance <- Crit Rating, Agility, Weapon Skill Rating"] = "Total Coups critiques = Score de critique + Agilité + Compétence d'arme"
+L["Sum Crit Chance"] = "Critiques"
+L["Crit Chance <- Crit Rating, Agility, Weapon Skill Rating"] = "Inclure le pourcentage de Coups critiques conféré par : Score de coup critique, Agilité, Compétence d'arme."
 -- /rb sum stat haste
 L["Sum Haste"] = "Hâte"
-L["Haste <- Haste Rating"] = "Total Hâte = Score de hâte"
+L["Haste <- Haste Rating"] = "Inclure le pourcentage de Hâte conféré par : le Score de hâte."
 -- /rb sum stat critspell
-L["Sum Spell Crit Chance"] = "Critique des sorts"
-L["Spell Crit Chance <- Spell Crit Rating, Intellect"] = "Total Coups critiques des sorts = Score de critique des sorts + Intelligence"
+L["Sum Spell Crit Chance"] = "Critiques des sorts"
+L["Spell Crit Chance <- Spell Crit Rating, Intellect"] = "Inclure le pourcentage de Coups critiques des sorts conféré par : Score de coup critique des sorts, Intelligence."
 -- /rb sum stat hitspell
 L["Sum Spell Hit Chance"] = "Toucher des sorts"
-L["Spell Hit Chance <- Spell Hit Rating"] = "Total Toucher des Sorts = Score de toucher des sorts"
+L["Spell Hit Chance <- Spell Hit Rating"] = "Inclure le pourcentage de Toucher des Sorts conféré par le Score de toucher des sorts."
 -- /rb sum stat hastespell
 L["Sum Spell Haste"] = "Hâte des sorts"
-L["Spell Haste <- Spell Haste Rating"] = "Total Hâte des sorts = Score de hâte des sorts"
+L["Spell Haste <- Spell Haste Rating"] = "Inclure le pourcentage de Hâte des sorts conféré par le Score de hâte des sorts."
 -- /rb sum stat mp5
-L["Sum Mana Regen"] = "Mp5"
-L["Mana Regen <- Mana Regen, Spirit"] = "Total Régénération de mana = Régénération de mana + Esprit"
+L["Sum Mana Regen"] = "Régén. mana"
+L["Mana Regen <- Mana Regen, Spirit"] = "Inclure la Régén. mana conféré par : Régén. mana, Esprit."
 -- /rb sum stat mp5nc
-L["Sum Mana Regen while not casting"] = "Mp5 (repos)"
-L["Mana Regen while not casting <- Spirit"] = "Total Régénération de mana hors incantation = Esprit"
+L["Sum Mana Regen while not casting"] = "Régén. mana (repos)"
+L["Mana Regen while not casting <- Spirit"] = "Inclure la Régén. mana hors incantation conféré par l'Esprit."
 -- /rb sum stat hp5
-L["Sum Health Regen"] = "Hp5"
-L["Health Regen <- Health Regen"] = "Total Régénération de santé = Régénération de santé"
+L["Sum Health Regen"] = "Régén. vie"
+L["Health Regen <- Health Regen"] = "Inclure la Régén. vie conféré par la Régén. vie."
 -- /rb sum stat hp5oc
-L["Sum Health Regen when out of combat"] = "Hp5 (repos)"
-L["Health Regen when out of combat <- Spirit"] = "Total Régénération de santé hors combat = Régénération de santé + Esprit"
+L["Sum Health Regen when out of combat"] = "Régén. vie (repos)"
+L["Health Regen when out of combat <- Spirit"] = "Inclure la Régén. vie hors combat conféré par : Régén. vie, Esprit."
 -- /rb sum stat armor
 L["Sum Armor"] = "Armure"
-L["Armor <- Armor from items, Armor from bonuses, Agility, Intellect"] = "Total Armure = Armure des objets + Armure bonus + Agilité + Intelligence"
+L["Armor <- Armor from items, Armor from bonuses, Agility, Intellect"] = "Inclure l'Armure conférée par : Armure des objets, Armure bonus, Agilité, Intelligence."
 -- /rb sum stat blockvalue
 L["Sum Block Value"] = "Valeur de blocage"
-L["Block Value <- Block Value, Strength"] = "Total Valeur de blocage = Valeur de blocage + Force"
+L["Block Value <- Block Value, Strength"] = "Inclure la Valeur de blocage conférée par : Valeur de blocage, Force."
 -- /rb sum stat dodge
 L["Sum Dodge Chance"] = "Esquive"
-L["Dodge Chance <- Dodge Rating, Agility, Defense Rating"] = "Total Esquive = Score d'esquive + Agilité + Score de défense"
+L["Dodge Chance <- Dodge Rating, Agility, Defense Rating"] = "Inclure l'Esquive conférée par : Score d'esquive, Agilité, Score de défense."
 -- /rb sum stat parry
 L["Sum Parry Chance"] = "Parade"
-L["Parry Chance <- Parry Rating, Defense Rating"] = "Total Parade = Score de parade + Score de défense"
+L["Parry Chance <- Parry Rating, Defense Rating"] = "Inclure la Parade conférée par : Score de parade, Score de défense."
 -- /rb sum stat block
-L["Sum Block Chance"] = "Chance de blocage"
-L["Block Chance <- Block Rating, Defense Rating"] = "Total Chance de blocage = Score de blocage + Score de défense"
+L["Sum Block Chance"] = "Chances de bloquer"
+L["Block Chance <- Block Rating, Defense Rating"] = "Inclure les Chances de bloquer conférées par : Score de blocage, Score de défense."
 -- /rb sum stat avoidhit
 L["Sum Hit Avoidance"] = "Évitement des coups"
-L["Hit Avoidance <- Defense Rating"] = "Total Évitement des coups = Score de défense"
+L["Hit Avoidance <- Defense Rating"] = "Inclure le pourcentage d'Évitement des coups conféré par le Score de défense."
 -- /rb sum stat avoidcrit
 L["Sum Crit Avoidance"] = "Évitement CC"
-L["Crit Avoidance <- Defense Rating, Resilience"] = "Total Évitement des Coups critiques = Score de défense + Résilience"
+L["Crit Avoidance <- Defense Rating, Resilience"] = "Inclure le pourcentage d'Évitement des Coups critiques conféré par : Score de défense, Résilience."
 -- /rb sum stat neglectdodge
-L["Sum Dodge Neglect"] = "Réduction Esquive"
-L["Dodge Neglect <- Expertise, Weapon Skill Rating"] = "Total Réduction d'esquive = Expertise + Compétence d'arme"
+L["Sum Dodge Neglect"] = "Diminution Esquive"
+L["Dodge Neglect <- Expertise, Weapon Skill Rating"] = "Inclure le pourcentage de Diminution d'esquive conféré par : Expertise, Compétence d'arme."
 -- /rb sum stat neglectparry
-L["Sum Parry Neglect"] = "Réduction Parade"
-L["Parry Neglect <- Expertise, Weapon Skill Rating"] = "Total Réduction de parade = Expertise + Compétence d'arme"
+L["Sum Parry Neglect"] = "Diminution Parade"
+L["Parry Neglect <- Expertise, Weapon Skill Rating"] = "Inclure le pourcentage de Diminution de parade conféré par : Expertise, Compétence d'arme."
 -- /rb sum stat neglectblock
-L["Sum Block Neglect"] = "Réduction Blocage"
-L["Block Neglect <- Weapon Skill Rating"] = "Total Réduction de blocage = Compétence d'arme"
+L["Sum Block Neglect"] = "Diminution Blocage"
+L["Block Neglect <- Weapon Skill Rating"] = "Inclure le pourcentage de Diminution de blocage conféré par la Compétence d'arme."
 -- /rb sum stat resarcane
-L["Sum Arcane Resistance"] = "Résistance : arcanes"
-L["Arcane Resistance Summary"] = "Inclure la Résistance aux arcanes."
+L["Sum Arcane Resistance"] = "Résistance : Arcanes"
+L["Arcane Resistance Summary"] = "Inclure la Résistance aux Arcanes."
 -- /rb sum stat resfire
-L["Sum Fire Resistance"] = "Résistance : feu"
-L["Fire Resistance Summary"] = "Inclure la Résistance au feu."
+L["Sum Fire Resistance"] = "Résistance : Feu"
+L["Fire Resistance Summary"] = "Inclure la Résistance au Feu."
 -- /rb sum stat resnature
-L["Sum Nature Resistance"] = "Résistance : nature"
-L["Nature Resistance Summary"] = "Inclure la Résistance à la nature."
+L["Sum Nature Resistance"] = "Résistance : Nature"
+L["Nature Resistance Summary"] = "Inclure la Résistance à la Nature."
 -- /rb sum stat resfrost
-L["Sum Frost Resistance"] = "Résistance : givre"
-L["Frost Resistance Summary"] = "Inclure la Résistance au givre."
+L["Sum Frost Resistance"] =  "Résistance : Givre"
+L["Frost Resistance Summary"] = "Inclure la Résistance au Givre."
 -- /rb sum stat resshadow
-L["Sum Shadow Resistance"] = "Résistance : ombre"
-L["Shadow Resistance Summary"] = "Inclure la Résistance à l'ombre."
+L["Sum Shadow Resistance"] = "Résistance : Ombre"
+L["Shadow Resistance Summary"] = "Inclure la Résistance à l'Ombre."
 -- /rb sum stat maxdamage
 L["Sum Weapon Max Damage"] = "Dégâts des armes max"
 L["Weapon Max Damage Summary"] = "Inclure la valeur la plus haute de la plage de dégâts des armes."
@@ -355,7 +355,7 @@ L["Ignore Armor Summary"] = "Inclure la Pénétration d'armure."
 --["Weapon DPS Summary"] = true,
 -- /rb sum statcomp str
 L["Sum Strength"] = "Force"
-L["Strength Summary"] = "Inclure la  Force."
+L["Strength Summary"] = "Inclure la Force."
 -- /rb sum statcomp Agilité
 L["Sum Agility"] = "Agilité"
 L["Agility Summary"] = "Inclure l'Agilité."
@@ -373,7 +373,7 @@ L["Sum Hit Rating"] = "Score de toucher"
 L["Hit Rating Summary"] = "Inclure le Score de toucher."
 -- /rb sum statcomp critrating
 L["Sum Crit Rating"] = "Score de critique"
-L["Crit Rating Summary"] = "Inclure le Score de critique."
+L["Crit Rating Summary"] = "Inclure le Score de coup critique."
 -- /rb sum statcomp hasterating
 L["Sum Haste Rating"] = "Score de hâte"
 L["Haste Rating Summary"] = "Inclure le Score de hâte."
@@ -382,7 +382,7 @@ L["Sum Spell Hit Rating"] = "Score de toucher des sorts"
 L["Spell Hit Rating Summary"] = "Inclure le Score de toucher des sorts."
 -- /rb sum statcomp critspellrating
 L["Sum Spell Crit Rating"] = "Score de critique des sorts"
-L["Spell Crit Rating Summary"] = "Inclure le Score de critique des sorts."
+L["Spell Crit Rating Summary"] = "Inclure le Score de coup critique des sorts."
 -- /rb sum statcomp hastespellrating
 L["Sum Spell Haste Rating"] = "Score de hâte des sorts"
 L["Spell Haste Rating Summary"] = "Inclure le Score de hâte des sorts."
@@ -400,37 +400,37 @@ L["Sum Resilience"] = "Score de résilience"
 L["Resilience Summary"] = "Inclure le Score de résilience."
 -- /rb sum statcomp def
 L["Sum Defense"] = "Défense"
-L["Defense <- Defense Rating"] = "Défense = Score de défense"
+L["Defense <- Defense Rating"] = "Inclure la valeur de Défense conférée par le Score de défense."
 -- /rb sum statcomp wpn
 L["Sum Weapon Skill"] = "Compétence d'arme"
-L["Weapon Skill <- Weapon Skill Rating"] = "Compétence d'arme = Score de compétence d'arme"
+L["Weapon Skill <- Weapon Skill Rating"] = "Inclure la Compétence d'arme conférée par le Score de compétence d'arme."
 -- /rb sum statcomp exp -- 2.3.0
 L["Sum Expertise"] = "Expertise"
-L["Expertise <- Expertise Rating"] = "Total Expertise = Score d'expertise"
+L["Expertise <- Expertise Rating"] = "Inclure la valeur d'Expertise conférée par le Score d'expertise."
 -- /rb sum statcomp tp
 L["Sum TankPoints"] = "TankPoints"
-L["TankPoints <- Health, Total Reduction"] = "TankPoints = Vie + Réduction totale"
+L["TankPoints <- Health, Total Reduction"] = "TankPoints = Points de vie, diminution totale"
 -- /rb sum statcomp tr
-L["Sum Total Reduction"] = "Réduction complète"
-L["Total Reduction <- Armor, Dodge, Parry, Block, Block Value, Defense, Resilience, MobMiss, MobCrit, MobCrush, DamageTakenMods"] = "Total Réduction complète = Armure + Equive + Parade + Blocage + Valeur de blocage + Défense + Résilience + MobMiss, MobCrit, MobCrush, DamageTakenMods"
+L["Sum Total Reduction"] = "Diminution complète"
+L["Total Reduction <- Armor, Dodge, Parry, Block, Block Value, Defense, Resilience, MobMiss, MobCrit, MobCrush, DamageTakenMods"] = "Inclure la diminution complète conféré par : Armure, Equive, Parade, Blocage, Valeur de blocage, Défense, Résilience, MobMiss, MobCrit, MobCrush, DamageTakenMods."
 -- /rb sum statcomp avoid
 L["Sum Avoidance"] = "Évitement"
-L["Avoidance <- Dodge, Parry, MobMiss, Block(Optional)"] = "Total Évitement = Esquive + Parade + Raté + Blocage(optionnel)"
+L["Avoidance <- Dodge, Parry, MobMiss, Block(Optional)"] = "Inclure l'Évitement conféré par : Esquive, Parade, Raté, Blocage(optionnel)."
 -- /rb sum gem
 L["Gems"] = "Gemmes"
 L["Auto fill empty gem slots"] = "Remplir automatiquement les châsses."
 -- /rb sum gem red
-L["Red Socket"] = EMPTY_SOCKET_RED
+L["Red Socket"] = "Châsse rouge"
 L["ItemID or Link of the gem you would like to auto fill"] = "ID ou lien (maj+clic) de la gemme que vous voudriez utliser."
 --["<ItemID|Link>"] = true,
 L["%s is now set to %s"] = "%s supposera désormais %s."
 L["Queried server for Gem: %s. Try again in 5 secs."] = "Requête serveur pour : %s. Rééssayez dans 5 secondes."
 -- /rb sum gem yellow
-L["Yellow Socket"] = EMPTY_SOCKET_YELLOW
+L["Yellow Socket"] = "Châsse jaune"
 -- /rb sum gem blue
-L["Blue Socket"] = EMPTY_SOCKET_BLUE
+L["Blue Socket"] = "Châsse bleue"
 -- /rb sum gem meta
-L["Meta Socket"] = EMPTY_SOCKET_META
+L["Meta Socket"] = "Méta-châsse"
 
 ----------------------
 -- Item Level and ID --
@@ -561,8 +561,8 @@ L["statList"] = {
 	{pattern = "score de hâte des sorts", id = CR_HASTE_SPELL},
 	{pattern = "score de hâte à distance", id = CR_HASTE_RANGED},
 	{pattern = "score de hâte", id = CR_HASTE_MELEE},
-	{pattern = "score de hâte en mêlée", id = CR_HASTE_MELEE}, -- [Tambours de Bataille] doesn't work
-	--{pattern = "score de hâte en mêlée, à distance et avec les sorts", id = CR_HASTE_SPELL}, --complete line for drums buff, doesn't work
+	{pattern = "score de hâte en mêlée", id = CR_HASTE_MELEE}, -- [Tambours de Bataille] "score de hâte en mêlée, à distance et avec les sorts" complete drums line
+	--{pattern = "skill rating", id = CR_WEAPON_SKILL},
 	{pattern = "score d’expertise", id = CR_EXPERTISE},
 	{pattern = "score d'expertise", id = CR_EXPERTISE},
 	{pattern = "score d'évitement des coups", id = CR_HIT_TAKEN_MELEE},
@@ -601,9 +601,9 @@ L["$value Dmg"] = "$value dégâts"
 L["$value Heal"] = "$value soins"
 L["$value Armor"] = "$value armure"
 L["$value Block"] = "$value blocage"
-L["$value MP5"] = "$value Mp5"
-L["$value MP5(NC)"] = "$value Mp5(repos)"
-L["$value HP5"] = "$value Hp5"
+L["$value MP5"] = "$value Régén. mana"
+L["$value MP5(NC)"] = "$value Régén. mana(repos)"
+L["$value HP5"] = "$value Régén. vie"
 L["$value to be Dodged/Parried"] = "$value esquivé/paré"
 L["$value to be Crit"] = "$value recevoir CC"
 L["$value Crit Dmg Taken"] = "$value dégâts CC"


### PR DESCRIPTION
Updated frFR localization. Tweaked it for some time now and I think it's ready despite some issues:

-I wasn't able to make "Show detailed conversions text" to work with expertise, it only affected the way resilience was displayed. Not sure if intended but as such, I worded it for resilience only
-Wasn't able to find out what Max Weapon Damage was. Is it weapon damage bonus from items or just weapon damage from weapons? Either way it seems to be broken for french.
-Stats summary in items tooltips (like Spell hit (%)) is still displayed half in english, half in french. The entries aren't in this file.

Thanks for resurrecting this addon. I remember using it for Cataclysm and I'm now very happy to have it for Classic TBC!