### PR TITLE
Add additional string for expertise to german locales

### DIFF
--- a/libs/StatLogic-1.0/deDE.lua
+++ b/libs/StatLogic-1.0/deDE.lua
@@ -389,6 +389,8 @@ L["StatIDLookup"] = {
 	["Erhöht die Fertigkeitswertung für unbewaffneten Kampf"] = {"FIST_WEAPON_RATING"}, -- Demonblood Eviscerator ID:27533
 
 	["Erhöht die Waffenkundewertung"] = {"EXPERTISE_RATING"},
+	["Erhöht Eure Waffenkundewertung"] = {"EXPERTISE_RATING"},
+
 	-- Exclude
 	["Sek"] = false,
 	["bis"] = false,


### PR DESCRIPTION
Item where the added string is in use, for reference:
https://de.tbc.wowhead.com/item=30257/gamaschen-von-shattrath