### PR TITLE
Compatibility changes

### DIFF
--- a/RatingBuster.lua
+++ b/RatingBuster.lua
@@ -1480,8 +1480,6 @@ function RatingBuster.ProcessTooltip(tooltip, name, link)
 			end
 
 		end
-		-- Workaround for strange spell power truncation bug
-		fontString:SetWidth(math.ceil(fontString:GetWidth()))
 	end
 	----------------------------
 	-- Item Level and Item ID --


### PR DESCRIPTION
I'm working on an addon which is also modifying tooltip lines. It's currently compatible with RatingBuster in enUS only, but these changes should allow for compatibility in any locale (without a lot of extra pattern matching).

What I'd like is to be able to have RatingBuster modify a single line of text at a time. I've pulled a bit out of the ProcessTooltip function and made it into a new ProcessLine function which can be run externally on any line of text. I could elaborate on why this is necessary if you'd like, but it makes compatibility far easier to be able to add in RatingBuster changes after my own.

I also have found that manually setting tooltip/fontString widths is unnecessary. I've been modifying tooltip lines for around a year and have never needed to manually set a width. It seems to recalculate padding in the OnShow() handler ([as indicated here](https://wowpedia.fandom.com/wiki/API_GameTooltip_AddLine#References)). So calling tooltip:Show() after modifying text ought be all you need (you already do this). If you set the width manually, then any other addons which modify text must also set the width manually since the automatic padding will no longer work.

As for da54c77eb4e2968b5ac166c13d0500921fe0c8c4, I don't know what originally caused #55 for some people, but I suspect that it also had to do with manually setting widths.