### PR TITLE
fix(StatLogic-enUS): Removes unused word 'rating' from Armor Penetration

### DIFF
--- a/libs/StatLogic/locales/enUS.lua
+++ b/libs/StatLogic/locales/enUS.lua
@@ -466,7 +466,7 @@ L["StatIDLookup"] = {
 	["Increases your expertise rating"] = {"EXPERTISE_RATING"},
 	["armor penetration rating"] = {"ARMOR_PENETRATION_RATING"}, -- gems
 	["Increases armor penetration rating"] = {"ARMOR_PENETRATION_RATING"},
-	["Increases your armor penetration rating"] = {"ARMOR_PENETRATION_RATING"}, -- ID:43178
+	["Increases your armor penetration"] = {"ARMOR_PENETRATION_RATING"}, -- ID:43178
 
 	-- Exclude
 	["sec"] = false,


### PR DESCRIPTION
closes #112 

See [item referenced in pre-existing comment](https://www.wowhead.com/wotlk/item=43178/ring-of-foul-mojo):

![image](https://user-images.githubusercontent.com/14095644/197366038-8eb28cdb-64f2-4dc5-852b-95a3c2f00870.png)
