### PR TITLE
Update frFR.lua on RB locales

### DIFF
--- a/locales/frFR.lua
+++ b/locales/frFR.lua
@@ -605,7 +605,7 @@ L["statList"] = {
 	{pattern = "score d’expertise", id = CR_EXPERTISE},
 	{pattern = "score d'expertise", id = CR_EXPERTISE},
 
-	{pattern = "score de pénétration d'armure", id = CR_ARMOR_PENETRATION},
+	{pattern = "pénétration d'armure", id = CR_ARMOR_PENETRATION},
 	{pattern = string.lower(ARMOR), id = ARMOR},
 	{pattern = "puissance d'attaque", id = ATTACK_POWER},
 }


### PR DESCRIPTION
https://www.wowhead.com/wotlk/item=44664/favor-of-the-dragon-queen wasn't showing any armor penetration because of a different phrasing