### PR TITLE
Update frFR.lua on StatLogic locales

### DIFF
--- a/libs/StatLogic/locales/frFR.lua
+++ b/libs/StatLogic/locales/frFR.lua
@@ -457,6 +457,7 @@ L["StatIDLookup"] = {
 	["score de pénétration d'armure"] = {"ARMOR_PENETRATION_RATING"},
 	["le score de pénétration d'armure"] = {"ARMOR_PENETRATION_RATING"},
 	["votre score de pénétration d'armure"] = {"ARMOR_PENETRATION_RATING"},
+	["la pénétration d'armure"] = {"ARMOR_PENETRATION_RATING"},
 
 	--ToDo
 	-- Exclude


### PR DESCRIPTION
https://www.wowhead.com/wotlk/item=44664/favor-of-the-dragon-queen wasn't showing any armor penetration because of a different phrasing