### PR TITLE
Add profile swap keybinding (Closes #109)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ Type `/rb` or `/ratingbuster` to open the options menu GUI, or add a slash comma
 - `space` - Add a empty line before or after stat summary
 	- `sumBlankLine` - Add a empty line before stat summary
 	- `sumBlankLineAfter` - Add a empty line after stat summary
-- `sumShowIcon` - Show the sigma icon before summary listing
-- `sumShowTitle` - Show the title text before summary listing
+- `sumShowIcon` - Show the sigma icon before stat summary
+- `sumShowTitle` - Show the title text before stat summary
 - `showZeroValueStat` - Show zero value stats in summary for consistancy
 - `calcSum` - Calculate the total stats for the item
 - `calcDiff` - Calculate the stat difference for the item and equipped items

--- a/RatingBuster.lua
+++ b/RatingBuster.lua
@@ -440,26 +440,32 @@ local options = {
 						sumShowIcon = {
 							type = 'toggle',
 							name = L["Show icon"],
-							desc = L["Show the sigma icon before summary listing"],
+							desc = L["Show the sigma icon before stat summary"],
 							order = 8,
 						},
 						sumShowTitle = {
 							type = 'toggle',
 							name = L["Show title text"],
-							desc = L["Show the title text before summary listing"],
+							desc = L["Show the title text before stat summary"],
 							order = 9,
+						},
+						sumShowProfile = {
+							type = 'toggle',
+							name = L["Show profile name"],
+							desc = L["Show profile name before stat summary"],
+							order = 10,
 						},
 						showZeroValueStat = {
 							type = 'toggle',
 							name = L["Show zero value stats"],
 							desc = L["Show zero value stats in summary for consistancy"],
-							order = 10,
+							order = 11,
 						},
 						sumSortAlpha = {
 							type = 'toggle',
 							name = L["Sort StatSummary alphabetically"],
 							desc = L["Enable to sort StatSummary alphabetically, disable to sort according to stat type(basic, physical, spell, tank)"],
-							order = 11,
+							order = 12,
 						},
 						sumStatColor = {
 							type = 'color',
@@ -467,7 +473,7 @@ local options = {
 							desc = L["Changes the color of added text"],
 							get = getColor,
 							set = setColor,
-							order = 12,
+							order = 13,
 						},
 						sumValueColor = {
 							type = 'color',
@@ -475,13 +481,13 @@ local options = {
 							desc = L["Changes the color of added text"],
 							get = getColor,
 							set = setColor,
-							order = 13,
+							order = 14,
 						},
 						space = {
 							type = 'group',
 							name = L["Add empty line"],
 							inline = true,
-							order = 14,
+							order = 15,
 							args = {
 								sumBlankLine = {
 									type = 'toggle',
@@ -1150,6 +1156,7 @@ local defaults = {
 		showItemLevel = false,
 		sumShowIcon = true,
 		sumShowTitle = true,
+		sumShowProfile = true,
 		showZeroValueStat = false,
 		sumSortAlpha = false,
 		sumStatColor = CreateColor(NORMAL_FONT_COLOR:GetRGBA()),
@@ -3564,12 +3571,28 @@ local function WriteSummary(tooltip, output)
 	if db.global.sumBlankLine then
 		tooltip:AddLine(" ")
 	end
+
+	local headerIcon
+	if db.global.sumShowIcon then
+		headerIcon = "|TInterface\\AddOns\\RatingBuster\\images\\Sigma:0|t "
+	end
+
+	local headerText
 	if db.global.sumShowTitle then
-		tooltip:AddLine(HIGHLIGHT_FONT_COLOR_CODE..L["Stat Summary"]..FONT_COLOR_CODE_CLOSE)
-		if db.global.sumShowIcon then
-			tooltip:AddTexture("Interface\\AddOns\\RatingBuster\\images\\Sigma")
+		headerText = L["StatSummary"]
+	end
+	if db.global.sumShowProfile then
+		local profile = db:GetCurrentProfile()
+		if headerText then
+			headerText = headerText .. ": " .. profile
+		else
+			headerText = profile
 		end
 	end
+	if headerIcon or headerText then
+		tooltip:AddLine((headerIcon or "") .. HIGHLIGHT_FONT_COLOR_CODE .. (headerText or "") .. FONT_COLOR_CODE_CLOSE)
+	end
+
 	local statR, statG, statB = db.global.sumStatColor:GetRGB()
 	local valueR, valueG, valueB = db.global.sumValueColor:GetRGB()
 	for _, o in ipairs(output) do

--- a/libs/StatLogic/Cata_Logic.lua
+++ b/libs/StatLogic/Cata_Logic.lua
@@ -900,24 +900,24 @@ if addon.class == "DRUID" then
 		["ADD_MASTERY_EFFECT_MOD_MASTERY"] = {
 			-- Mastery: Total Eclipse
 			{
-				["mastery"] = 77492,
+				["spec"] = 1,
 				["value"] = 2,
 			},
 			-- Mastery: Razor Claws (Cat Form)
 			{
-				["mastery"] = 77493,
+				["spec"] = 2,
 				["value"] = 3.1,
 				["aura"] = 768,
 			},
 			-- Mastery: Savage Defender (Bear Form)
 			{
-				["mastery"] = 77494,
+				["spec"] = 2,
 				["value"] = 4,
 				["aura"] = 5487,
 			},
 			-- Mastery: Harmony
 			{
-				["mastery"] = 77495,
+				["spec"] = 3,
 				["value"] = 1.25,
 			},
 		},
@@ -971,12 +971,12 @@ if addon.class == "DRUID" then
 				},
 			},
 		},
-		-- Healers: Meditation
-		-- 4.0.1: Allows 50% of your mana regeneration from Spirit to continue while in combat.
 		["ADD_MANA_REG_MOD_NORMAL_MANA_REG"] = {
+			-- Passive: Meditation
 			{
 				["value"] = 0.50,
-				["known"] = 85101, -- ["Meditation"]
+				["spellid"] = 85101,
+				["spec"] = 3,
 			},
 		},
 		["ADD_DODGE"] = {
@@ -1115,22 +1115,21 @@ if addon.class == "DRUID" then
 				["aura"] = 768,        -- ["Cat Form"],
 			},
 		},
-		-- Druid: Heart of the Wild (Rank 5) - 3,4
-		-- 4.0.1: Increases your Intellect by 2/4/6%. In addition, while in Bear Form your Stamina is increased by 3/7/10% and while in Cat Form your attack power is increased by 3/7/10%.
-		-- Druid: Aggression - Passive: 84735
-		-- 4.0.1: Increases your attack power by 25%.
 		["MOD_AP"] = {
+			-- Talent: Heart of the Wild (Cat Form)
 			{
 				["tab"] = 3,
 				["num"] = 4,
 				["rank"] = {
 					0.03, 0.07, 0.1,
 				},
-				["aura"] = 768,        -- ["Cat Form"],
+				["aura"] = 768,
 			},
+			-- Passive: Aggression
 			{
 				["value"] = 0.25,
-				["known"] = 84735, -- ["Aggression"]
+				["spellid"] = 84735,
+				["spec"] = 2,
 			},
 		},
 		-- Druid: Leather Specialization - Passive: 86530
@@ -1161,17 +1160,17 @@ elseif addon.class == "DEATHKNIGHT" then
 		["ADD_MASTERY_EFFECT_MOD_MASTERY"] = {
 			-- Mastery: Blood Shield
 			{
-				["mastery"] = 77513,
+				["spec"] = 1,
 				["value"] = 6.25,
 			},
 			-- Mastery: Frozen Heart
 			{
-				["mastery"] = 77514,
+				["spec"] = 2,
 				["value"] = 2,
 			},
 			-- Mastery: Dreadblade
 			{
-				["mastery"] = 77515,
+				["spec"] = 3,
 				["value"] = 2.5,
 			},
 		},
@@ -1287,20 +1286,8 @@ elseif addon.class == "DEATHKNIGHT" then
 				["enchant"] = 3883,
 			},
 		},
-		-- Death Knight: Plate Specialization - Passive: 86524
-		-- 4.0.1: Increases your primary attribute by 5% while wearing Plate in all armor slots. Blood specialization grants Stamina, Frost specialization grants Strength, and Unholy specialization grants Strength.
-		-- Death Knight: Unholy Might - Passive: 91107
-		-- 4.2.0: Dark power courses through your limbs, increasing your Strength by 20%.
-		-- Death Knight: Abomination's Might - 1,11
-		-- 4.0.1: Also increases your total Strength by 1%/2%.
-		-- Death Knight: Pillar of Frost - Buff: 51271
-		-- 4.0.1: Strength increased by 20%.
-		-- Death Knight: Brittle Bones - Rank 2/2 - 2,14
-		-- 4.0.1: Your Strength is increased by 2/4%
-		-- Death Knight: Unholy Strength - Buff: 53365
-		-- 4.0.1: Strength increased by 15%
 		["MOD_STR"] = {
-			-- Plate Specialization
+			-- Plate Specialization (Frost, Unholy)
 			{
 				["value"] = 0.05,
 				["known"] = 86524,
@@ -1309,12 +1296,13 @@ elseif addon.class == "DEATHKNIGHT" then
 					[3] = true,
 				},
 			},
-			-- Unholy Might
+			-- Passive: Unholy Might
 			{
-				["value"] = 0.2,
-				["known"] = 91107, -- ["Unholy Might"]
+				["value"] = 0.25,
+				["spellid"] = 91107,
+				["spec"] = 3,
 			},
-			-- Abomination's Might
+			-- Talent: Abomination's Might
 			{
 				["tab"] = 1,
 				["num"] = 11,
@@ -1322,12 +1310,12 @@ elseif addon.class == "DEATHKNIGHT" then
 					0.01, 0.02,
 				},
 			},
-			-- Pillar of Frost
+			-- Buff: Pillar of Frost
 			{
 				["value"] = 0.2,
-				["aura"] = 51271,        -- ["Pillar of Frost"],
+				["aura"] = 51271,
 			},
-			-- Brittle Bones
+			-- Talent: Brittle Bones
 			{
 				["tab"] = 2,
 				["num"] = 14,
@@ -1335,10 +1323,10 @@ elseif addon.class == "DEATHKNIGHT" then
 					0.02, 0.04,
 				},
 			},
-			-- Unholy Strength
+			-- Buff: Unholy Strength
 			{
 				["value"] = 0.15,
-				["aura"] = 53365,        -- ["Unholy Strength"],
+				["aura"] = 53365,
 			},
 		},
 	}
@@ -1347,17 +1335,17 @@ elseif addon.class == "HUNTER" then
 		["ADD_MASTERY_EFFECT_MOD_MASTERY"] = {
 			-- Mastery: Master of Beasts
 			{
-				["mastery"] = 76657,
+				["spec"] = 1,
 				["value"] = 1.67,
 			},
 			-- Mastery: Wild Quiver
 			{
-				["mastery"] = 76659,
+				["spec"] = 2,
 				["value"] = 2.1,
 			},
 			-- Mastery: Essence of the Viper
 			{
-				["mastery"] = 76658,
+				["spec"] = 3,
 				["value"] = 1,
 			},
 		},
@@ -1385,13 +1373,12 @@ elseif addon.class == "HUNTER" then
 				["value"] = -5.4500,
 			},
 		},
-		-- Hunter: Animal Handler - Passive: 87325
-		-- 4.0.6: Attack Power increased by 25%.
 		["MOD_AP"] = {
-			-- Animal Handler
+			-- Passive: Animal Handler
 			{
 				["value"] = 0.25,
-				["known"] = 87325, -- ["Animal Handler"]
+				["spellid"] = 87325,
+				["spec"] = 1,
 			},
 		},
 		-- Hunter: Hunter vs. Wild - Rank 3/3 - 3,1
@@ -1406,8 +1393,6 @@ elseif addon.class == "HUNTER" then
 				},
 			},
 		},
-		-- Hunter: Mail Specialization - Passive: 86528
-		-- 4.0.1: Increases your Agility by 5% while wearing Mail in all armor slots
 		["MOD_AGI"] = {
 			-- Mail Specialization
 			{
@@ -1420,14 +1405,13 @@ elseif addon.class == "HUNTER" then
 					[3] = true,
 				},
 			},
-			-- Hunter: Into the Wilderness - Passive: 84729
-			-- 4.0.1: Agility increased by 10%.
+			-- Passive: Into the Wilderness
 			{
 				["value"] = 0.1,
-				["known"] = 84729, -- ["Into the Wilderness"]
+				["spellid"] = 84729,
+				["spec"] = 3,
 			},
-			-- Hunter: Hunting Party - Rank 1/1 - 3,17
-			-- 4.0.6: Increases your total Agility by an additional 2%
+			-- Talent: Hunting Party
 			{
 				["tab"] = 3,
 				["num"] = 17,
@@ -1440,17 +1424,17 @@ elseif addon.class == "MAGE" then
 		["ADD_MASTERY_EFFECT_MOD_MASTERY"] = {
 			-- Mastery: Mana Adept
 			{
-				["mastery"] = 76547,
+				["spec"] = 1,
 				["value"] = 1.5,
 			},
 			-- Mastery: Flashburn
 			{
-				["mastery"] = 76595,
+				["spec"] = 2,
 				["value"] = 2.8,
 			},
 			-- Mastery: Frostburn
 			{
-				["mastery"] = 76613,
+				["spec"] = 3,
 				["value"] = 2.5,
 			},
 		},
@@ -1544,24 +1528,24 @@ elseif addon.class == "PALADIN" then
 		["ADD_MASTERY_EFFECT_MOD_MASTERY"] = {
 			-- Mastery: Illuminated Healing
 			{
-				["mastery"] = 76669,
+				["spec"] = 1,
 				["value"] = 1.5,
 			},
 			-- Mastery: Divine Bulwark
 			{
-				["mastery"] = 76671,
+				["spec"] = 2,
 				["value"] = 2.25,
 			},
 			-- Mastery: Hand of Light
 			{
-				["mastery"] = 76672,
+				["spec"] = 3,
 				["value"] = 2.1,
 			},
 		},
 		["ADD_BLOCK_CHANCE_MOD_MASTERY_EFFECT"] = {
 			-- Mastery: Divine Bulwark
 			{
-				["mastery"] = 76671,
+				["spec"] = 2,
 				["value"] = 1,
 			},
 		},
@@ -1600,10 +1584,11 @@ elseif addon.class == "PALADIN" then
 			},
 		},
 		["ADD_MANA_REG_MOD_NORMAL_MANA_REG"] = {
-			-- Meditation
+			-- Passive: Meditation
 			{
 				["value"] = 0.50,
-				["known"] = 95859,
+				["spellid"] = 95859,
+				["spec"] = 1,
 			},
 			-- Talent: Judgements of the Pure
 			{
@@ -1632,40 +1617,36 @@ elseif addon.class == "PALADIN" then
 				["value"] = 0.27,
 			},
 		},
-		-- Paladin: Sheath of Light - Passive: 53503
-		-- 4.0.1: Increases your spell power by an amount equal to 30% of your attack power
 		["ADD_SPELL_DMG_MOD_AP"] = {
-			-- Sheath of Light
+			-- Passive: Sheath of Light
 			{
-				["value"] = 0.3,
-				["known"] = 53503,
+				["value"] = 0.30,
+				["spellid"] = 53503,
+				["spec"] = 3,
 			},
 		},
-		-- Paladin: Sheath of Light - Passive: 53503
-		-- 4.0.1: Increases your spell power by an amount equal to 30% of your attack power
 		["ADD_HEALING_MOD_AP"] = {
-			-- Sheath of Light
+			-- Passive: Sheath of Light
 			{
-				["value"] = 0.3,
-				["known"] = 53503,
+				["value"] = 0.30,
+				["spellid"] = 53503,
+				["spec"] = 3,
 			},
 		},
-		-- Paladin: Touched by the Light - Passive: 53592
-		-- 4.0.1: Increases your total Stamina by 15%, increases your spell hit by 6%, and increases your spell power by an amount equal to 60% of your Strength.
 		["ADD_SPELL_DMG_MOD_STR"] = {
-			-- Touched by the Light
+			-- Passive: Touched by the Light
 			{
-				["value"] = 0.6,
-				["known"] = 53592,
+				["value"] = 0.60,
+				["spellid"] = 53592,
+				["spec"] = 2,
 			},
 		},
-		-- Paladin: Touched by the Light - Passive: 53592
-		-- 4.0.1: Increases your total Stamina by 15%, increases your spell hit by 6%, and increases your spell power by an amount equal to 60% of your Strength.
 		["ADD_HEALING_MOD_STR"] = {
-			-- Touched by the Light
+			-- Passive: Touched by the Light
 			{
-				["value"] = 0.6,
-				["known"] = 53592,
+				["value"] = 0.60,
+				["spellid"] = 53592,
+				["spec"] = 2,
 			},
 		},
 		-- Paladin: Toughness - Rank 3/3 - 2,5
@@ -1679,10 +1660,6 @@ elseif addon.class == "PALADIN" then
 				},
 			},
 		},
-		-- Paladin: Plate Specialization - Passive: 86525
-		-- 4.0.1: Increases your primary attribute by 5% while wearing Plate in all armor slots. Holy specialization grants Intellect, Protection specialization grants Stamina, and Retribution specialization grants Strength.
-		-- Paladin: Touched by the Light - Passive: 53592
-		-- 4.0.1: Increases your total Stamina by 15%, increases your spell hit by 6%, and increases your spell power by an amount equal to 60% of your Strength.
 		["MOD_STA"] = {
 			-- Plate Specialization
 			{
@@ -1692,10 +1669,11 @@ elseif addon.class == "PALADIN" then
 					[2] = true,
 				},
 			},
-			-- Touched by the Light
+			-- Passive: Touched by the Light
 			{
 				["value"] = 0.15,
-				["known"] = 53592,
+				["spellid"] = 53592,
+				["spec"] = 2,
 			},
 		},
 		-- Paladin: Plate Specialization - Passive: 86525
@@ -1728,17 +1706,17 @@ elseif addon.class == "PRIEST" then
 		["ADD_MASTERY_EFFECT_MOD_MASTERY"] = {
 			-- Mastery: Shield Discipline
 			{
-				["mastery"] = 77484,
+				["spec"] = 1,
 				["value"] = 2.5,
 			},
 			-- Mastery: Echo of Light
 			{
-				["mastery"] = 77485,
+				["spec"] = 2,
 				["value"] = 1.25,
 			},
 			-- Mastery: Shadow Orb Power
 			{
-				["mastery"] = 77486,
+				["spec"] = 3,
 				["value"] = 1.45,
 			},
 		},
@@ -1777,17 +1755,17 @@ elseif addon.class == "PRIEST" then
 			},
 		},
 		["ADD_MANA_REG_MOD_NORMAL_MANA_REG"] = {
-			-- Meditation (Discipline)
-			-- 4.0.1: Allows 50% of your mana regeneration from Spirit to continue while in combat.
+			-- Passive: Meditation (Discipline)
 			{
 				["value"] = 0.5,
-				["known"] = 95860,
+				["spellid"] = 95860,
+				["spec"] = 1,
 			},
-			-- Meditation (Holy)
-			-- 4.0.1: Allows 50% of your mana regeneration from Spirit to continue while in combat.
+			-- Passive: Meditation (Holy)
 			{
 				["value"] = 0.5,
-				["known"] = 95861,
+				["spellid"] = 95861,
+				["spec"] = 2,
 			},
 			-- Talent: Holy Concentration
 			{
@@ -1840,7 +1818,8 @@ elseif addon.class == "PRIEST" then
 			-- Passive: Enlightenment
 			{
 				["value"] = 0.15,
-				["known"] = 84732,
+				["spellid"] = 84732,
+				["spec"] = 1,
 			},
 			-- Passive: Mysticism
 			{
@@ -1854,17 +1833,17 @@ elseif addon.class == "ROGUE" then
 		["ADD_MASTERY_EFFECT_MOD_MASTERY"] = {
 			-- Mastery: Potent Poisons
 			{
-				["mastery"] = 76803,
+				["spec"] = 1,
 				["value"] = 3.5,
 			},
 			-- Mastery: Main Gauche
 			{
-				["mastery"] = 76806,
+				["spec"] = 2,
 				["value"] = 2,
 			},
 			-- Mastery: Executioner
 			{
-				["mastery"] = 76808,
+				["spec"] = 3,
 				["value"] = 2.5,
 			},
 		},
@@ -1886,12 +1865,8 @@ elseif addon.class == "ROGUE" then
 				["value"] = 1,
 			},
 		},
-		-- Rogue: Savage Combat - Rank 2/2 - 2,16
-		-- 4.2.0: Increases your total attack power by 3/6%.
-		-- Rogue: Vitality - Passive: 61329
-		-- 4.2.0: Increases your Attack Power by 30%.
 		["MOD_AP"] = {
-			-- Savage Combat
+			-- Talent: Savage Combat
 			{
 				["tab"] = 2,
 				["num"] = 16,
@@ -1899,10 +1874,11 @@ elseif addon.class == "ROGUE" then
 					0.03, 0.06,
 				},
 			},
-			-- Vitality
+			-- Passive: Vitality
 			{
-				["value"] = 0.3,
-				["known"] = 61329,
+				["value"] = 0.30,
+				["spellid"] = 61329,
+				["spec"] = 2,
 			},
 		},
 		-- Rogue: Reinforced Leather - Rank 2/2 - 2,10
@@ -1941,10 +1917,6 @@ elseif addon.class == "ROGUE" then
 				["aura"] = 31022,
 			},
 		},
-		-- Rogue: Leather Specialization - Passive: 86531
-		-- 4.0.1: Increases your Agility by 5% while wearing Leather in all armor slots.
-		-- Rogue: Sinister Calling - Passive: 31220
-		-- 4.0.6: Increases your total Agility by 30%
 		["MOD_AGI"] = {
 			-- Leather Specialization
 			{
@@ -1957,10 +1929,11 @@ elseif addon.class == "ROGUE" then
 					[3] = true,
 				},
 			},
-			-- Sinister Calling
+			-- Passive: Sinister Calling
 			{
-				["value"] = 0.3,
-				["known"] = 31220,
+				["value"] = 0.30,
+				["spellid"] = 31220,
+				["spec"] = 3,
 			},
 		},
 	}
@@ -1969,17 +1942,17 @@ elseif addon.class == "SHAMAN" then
 		["ADD_MASTERY_EFFECT_MOD_MASTERY"] = {
 			-- Mastery: Elemental Overload
 			{
-				["mastery"] = 77222,
+				["spec"] = 1,
 				["value"] = 2,
 			},
 			-- Mastery: Enhanced Elements
 			{
-				["mastery"] = 77223,
+				["spec"] = 2,
 				["value"] = 2.5,
 			},
 			-- Mastery: Deep Healing
 			{
-				["mastery"] = 77226,
+				["spec"] = 3,
 				["value"] = 3,
 			},
 		},
@@ -2003,7 +1976,8 @@ elseif addon.class == "SHAMAN" then
 			-- Passive: Mental Quickness
 			{
 				["value"] = -1,
-				["known"] = 30814,
+				["spellid"] = 30814,
+				["spec"] = 2,
 			},
 		},
 		["ADD_HEALING_MOD_INT"] = {
@@ -2014,7 +1988,8 @@ elseif addon.class == "SHAMAN" then
 			-- Passive: Mental Quickness
 			{
 				["value"] = -1,
-				["known"] = 30814,
+				["spellid"] = 30814,
+				["spec"] = 2,
 			},
 		},
 		["ADD_DODGE"] = {
@@ -2043,26 +2018,28 @@ elseif addon.class == "SHAMAN" then
 				},
 			},
 		},
-		-- Healers: Meditation
-		-- 4.0.1: Allows 50% of your mana regeneration from Spirit to continue while in combat.
 		["ADD_MANA_REG_MOD_NORMAL_MANA_REG"] = {
+			-- Passive: Meditation
 			{
 				["value"] = 0.50,
-				["known"] = 95862,
+				["spellid"] = 95862,
+				["spec"] = 3,
 			},
 		},
 		["ADD_SPELL_DMG_MOD_AP"] = {
 			-- Passive: Mental Quickness
 			{
 				["value"] = 0.55,
-				["known"] = 30814,
+				["spellid"] = 30814,
+				["spec"] = 2,
 			},
 		},
 		["ADD_HEALING_MOD_AP"] = {
 			-- Passive: Mental Quickness
 			{
 				["value"] = 0.55,
-				["known"] = 30814,
+				["spellid"] = 30814,
+				["spec"] = 2,
 			},
 		},
 		-- Shaman: Toughness - Rank 3/3 - 2,8
@@ -2114,17 +2091,17 @@ elseif addon.class == "WARLOCK" then
 		["ADD_MASTERY_EFFECT_MOD_MASTERY"] = {
 			-- Mastery: Potent Afflictions
 			{
-				["mastery"] = 77215,
+				["spec"] = 1,
 				["value"] = 1.63,
 			},
 			-- Mastery: Master Demonologist
 			{
-				["mastery"] = 77219,
+				["spec"] = 2,
 				["value"] = 2.3,
 			},
 			-- Mastery: Fiery Apocalypse
 			{
-				["mastery"] = 77220,
+				["spec"] = 3,
 				["value"] = 1.35,
 			},
 		},
@@ -2195,24 +2172,24 @@ elseif addon.class == "WARRIOR" then
 		["ADD_MASTERY_EFFECT_MOD_MASTERY"] = {
 			-- Mastery: Strikes of Opportunity
 			{
-				["mastery"] = 76838,
+				["spec"] = 1,
 				["value"] = 2.2,
 			},
 			-- Mastery: Unshackled Fury
 			{
-				["mastery"] = 76856,
+				["spec"] = 2,
 				["value"] = 5.6,
 			},
 			-- Mastery: Critical Block
 			{
-				["mastery"] = 76857,
+				["spec"] = 3,
 				["value"] = 1.5,
 			},
 		},
 		["ADD_BLOCK_CHANCE_MOD_MASTERY_EFFECT"] = {
 			-- Mastery: Critical Block
 			{
-				["mastery"] = 76857,
+				["spec"] = 3,
 				["value"] = 1,
 			},
 		},
@@ -2262,10 +2239,6 @@ elseif addon.class == "WARRIOR" then
 				},
 			},
 		},
-		-- Warrior: Plate Specialization - Passive: 86526
-		-- 4.0.1: Increases your primary attribute by 5% while wearing Plate in all armor slots. Arms specialization grants Strength, Fury specialization grants Strength, and Protection specialization grants Stamina.
-		-- Warrior: Sentinel - Passive: 29144
-		-- 4.0.1: Increases your total Stamina by 15%
 		["MOD_STA"] = {
 			-- Plate Specialization
 			{
@@ -2275,10 +2248,11 @@ elseif addon.class == "WARRIOR" then
 					[3] = true,
 				},
 			},
-			-- Sentinel
+			-- Passive: Sentinel
 			{
 				["value"] = 0.15,
-				["known"] = 29144,
+				["spellid"] = 29144,
+				["spec"] = 3,
 			},
 		},
 		-- Warrior: Plate Specialization - Passive: 86526

--- a/locales/deDE.lua
+++ b/locales/deDE.lua
@@ -125,7 +125,7 @@ L["Add after summary"] = "Nach Berechnung hinzufügen"
 L["Add a empty line after stat summary"] = "Füge eine leere Zeile nach der Werteübersicht hinzu"
 -- /rb sum icon
 L["Show icon"] = "Zeige Symbol"
-L["Show the sigma icon before summary listing"] = "Zeige das Sigma Symbol vor der Übersichtsliste an"
+L["Show the sigma icon before stat summary"] = "Zeige das Sigma Symbol vor der Übersichtsliste an"
 -- /rb sum title
 L["Show title text"] = "Zeige Titeltext"
 L["Show the title text before stat summary"] = "Zeige Titeltext vor der Übersichtsliste an"

--- a/locales/deDE.lua
+++ b/locales/deDE.lua
@@ -1,4 +1,4 @@
-﻿--[[
+--[[
 Name: RatingBuster deDE locale
 Revision: $Revision: 75639 $
 Translated by:
@@ -128,7 +128,9 @@ L["Show icon"] = "Zeige Symbol"
 L["Show the sigma icon before summary listing"] = "Zeige das Sigma Symbol vor der Übersichtsliste an"
 -- /rb sum title
 L["Show title text"] = "Zeige Titeltext"
-L["Show the title text before summary listing"] = "Zeige Titeltext vor der Übersichtsliste an"
+L["Show the title text before stat summary"] = "Zeige Titeltext vor der Übersichtsliste an"
+L["Show profile name"] = "Show profile name"
+L["Show profile name before stat summary"] = "Show profile name before stat summary"
 -- /rb sum showzerostat
 L["Show zero value stats"] = "Zeige Nullwerte"
 L["Show zero value stats in summary for consistancy"] = "Zeige zur Konsistenz die Nullwerte in der Übersicht an"
@@ -257,6 +259,14 @@ L["Raid Buffs"] = "Raidbuffs"
 L["Stat Multiplier"] = "Wertemultiplikatoren"
 L["Attack Power Multiplier"] = "Angriffskraft-Multiplikatoren"
 L["Reduced Physical Damage Taken"] = "Reduzierter erlittener physischer Schaden"
+
+L["Swap Profiles"] = "Swap Profiles"
+L["Swap Profile Keybinding"] = "Swap Profile Keybinding"
+L["Use a keybind to swap between Primary and Secondary Profiles.\n\nIf \"Enable spec profiles\" is enabled, will use the Primary and Secondary Talents profiles, and will preview items with that spec's talents, glyphs, and passives.\n\nYou can re-use an existing keybind! It will only be used for RatingBuster when an item tooltip is shown."] = "Use a keybind to swap between Primary and Secondary Profiles.\n\nIf \"Enable spec profiles\" is enabled, will use the Primary and Secondary Talents profiles, and will preview items with that spec's talents, glyphs, and passives.\n\nYou can re-use an existing keybind! It will only be used for RatingBuster when an item tooltip is shown."
+L["Primary Profile"] = "Primary Profile"
+L["Select the primary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Primary Talents profile."] = "Select the primary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Primary Talents profile."
+L["Secondary Profile"] = "Secondary Profile"
+L["Select the secondary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Secondary Talents profile."] = "Select the secondary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Secondary Talents profile."
 
 -----------------------
 -- Matching Patterns --

--- a/locales/enUS.lua
+++ b/locales/enUS.lua
@@ -131,7 +131,7 @@ L["Add after summary"] = true
 L["Add a empty line after stat summary"] = true
 -- /rb sum icon
 L["Show icon"] = true
-L["Show the sigma icon before summary listing"] = true
+L["Show the sigma icon before stat summary"] = true
 -- /rb sum title
 L["Show title text"] = true
 L["Show the title text before stat summary"] = true

--- a/locales/enUS.lua
+++ b/locales/enUS.lua
@@ -1,4 +1,4 @@
-﻿--[[
+--[[
 Name: RatingBuster enUS locale
 Revision: $Revision: 73696 $
 Translated by:
@@ -134,7 +134,9 @@ L["Show icon"] = true
 L["Show the sigma icon before summary listing"] = true
 -- /rb sum title
 L["Show title text"] = true
-L["Show the title text before summary listing"] = true
+L["Show the title text before stat summary"] = true
+L["Show profile name"] = true
+L["Show profile name before stat summary"] = true
 -- /rb sum showzerostat
 L["Show zero value stats"] = true
 L["Show zero value stats in summary for consistancy"] = true
@@ -264,6 +266,14 @@ L["Raid Buffs"] = true
 L["Stat Multiplier"] = true
 L["Attack Power Multiplier"] = true
 L["Reduced Physical Damage Taken"] = true
+
+L["Swap Profiles"] = true
+L["Swap Profile Keybinding"] = true
+L["Use a keybind to swap between Primary and Secondary Profiles.\n\nIf \"Enable spec profiles\" is enabled, will use the Primary and Secondary Talents profiles, and will preview items with that spec's talents, glyphs, and passives.\n\nYou can re-use an existing keybind! It will only be used for RatingBuster when an item tooltip is shown."] = true
+L["Primary Profile"] = true
+L["Select the primary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Primary Talents profile."] = true
+L["Secondary Profile"] = true
+L["Select the secondary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Secondary Talents profile."] = true
 
 -----------------------
 -- Matching Patterns --

--- a/locales/esES.lua
+++ b/locales/esES.lua
@@ -129,7 +129,9 @@ L["Show icon"] = "Mostrar icono"
 L["Show the sigma icon before summary listing"] = "Muestra el icono de sumatorio antes del listado resumen"
 -- /rb sum title
 L["Show title text"] = "Mostrar texto titulo"
-L["Show the title text before summary listing"] = "Muestra el titulo antes del listado resumen"
+L["Show the title text before stat summary"] = "Muestra el titulo antes del listado resumen"
+L["Show profile name"] = "Show profile name"
+L["Show profile name before stat summary"] = "Show profile name before stat summary"
 -- /rb sum showzerostat
 L["Show zero value stats"] = "Mostrar estad. valor cero"
 L["Show zero value stats in summary for consistancy"] = "Muestra las estad. de valor cero por consistencia"
@@ -258,6 +260,14 @@ L["Raid Buffs"] = "Raid Buffs"
 L["Stat Multiplier"] = "Stat Multiplier"
 L["Attack Power Multiplier"] = "Attack Power Multiplier"
 L["Reduced Physical Damage Taken"] = "Reduced Physical Damage Taken"
+
+L["Swap Profiles"] = "Swap Profiles"
+L["Swap Profile Keybinding"] = "Swap Profile Keybinding"
+L["Use a keybind to swap between Primary and Secondary Profiles.\n\nIf \"Enable spec profiles\" is enabled, will use the Primary and Secondary Talents profiles, and will preview items with that spec's talents, glyphs, and passives.\n\nYou can re-use an existing keybind! It will only be used for RatingBuster when an item tooltip is shown."] = "Use a keybind to swap between Primary and Secondary Profiles.\n\nIf \"Enable spec profiles\" is enabled, will use the Primary and Secondary Talents profiles, and will preview items with that spec's talents, glyphs, and passives.\n\nYou can re-use an existing keybind! It will only be used for RatingBuster when an item tooltip is shown."
+L["Primary Profile"] = "Primary Profile"
+L["Select the primary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Primary Talents profile."] = "Select the primary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Primary Talents profile."
+L["Secondary Profile"] = "Secondary Profile"
+L["Select the secondary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Secondary Talents profile."] = "Select the secondary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Secondary Talents profile."
 
 -----------------------
 -- Matching Patterns --

--- a/locales/esES.lua
+++ b/locales/esES.lua
@@ -126,7 +126,7 @@ L["Add after summary"] = "Anadir despues del resumen"
 L["Add a empty line after stat summary"] = "Anade una linea vacia despues del resumen"
 -- /rb sum icon
 L["Show icon"] = "Mostrar icono"
-L["Show the sigma icon before summary listing"] = "Muestra el icono de sumatorio antes del listado resumen"
+L["Show the sigma icon before stat summary"] = "Muestra el icono de sumatorio antes del listado resumen"
 -- /rb sum title
 L["Show title text"] = "Mostrar texto titulo"
 L["Show the title text before stat summary"] = "Muestra el titulo antes del listado resumen"

--- a/locales/esMX.lua
+++ b/locales/esMX.lua
@@ -129,7 +129,9 @@ L["Show icon"] = "Mostrar icono"
 L["Show the sigma icon before summary listing"] = "Muestra el icono de sumatorio antes del listado resumen"
 -- /rb sum title
 L["Show title text"] = "Mostrar texto titulo"
-L["Show the title text before summary listing"] = "Muestra el titulo antes del listado resumen"
+L["Show the title text before stat summary"] = "Muestra el titulo antes del listado resumen"
+L["Show profile name"] = "Show profile name"
+L["Show profile name before stat summary"] = "Show profile name before stat summary"
 -- /rb sum showzerostat
 L["Show zero value stats"] = "Mostrar estad. valor cero"
 L["Show zero value stats in summary for consistancy"] = "Muestra las estad. de valor cero por consistencia"
@@ -258,6 +260,14 @@ L["Raid Buffs"] = "Raid Buffs"
 L["Stat Multiplier"] = "Stat Multiplier"
 L["Attack Power Multiplier"] = "Attack Power Multiplier"
 L["Reduced Physical Damage Taken"] = "Reduced Physical Damage Taken"
+
+L["Swap Profiles"] = "Swap Profiles"
+L["Swap Profile Keybinding"] = "Swap Profile Keybinding"
+L["Use a keybind to swap between Primary and Secondary Profiles.\n\nIf \"Enable spec profiles\" is enabled, will use the Primary and Secondary Talents profiles, and will preview items with that spec's talents, glyphs, and passives.\n\nYou can re-use an existing keybind! It will only be used for RatingBuster when an item tooltip is shown."] = "Use a keybind to swap between Primary and Secondary Profiles.\n\nIf \"Enable spec profiles\" is enabled, will use the Primary and Secondary Talents profiles, and will preview items with that spec's talents, glyphs, and passives.\n\nYou can re-use an existing keybind! It will only be used for RatingBuster when an item tooltip is shown."
+L["Primary Profile"] = "Primary Profile"
+L["Select the primary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Primary Talents profile."] = "Select the primary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Primary Talents profile."
+L["Secondary Profile"] = "Secondary Profile"
+L["Select the secondary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Secondary Talents profile."] = "Select the secondary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Secondary Talents profile."
 
 -----------------------
 -- Matching Patterns --

--- a/locales/esMX.lua
+++ b/locales/esMX.lua
@@ -126,7 +126,7 @@ L["Add after summary"] = "Anadir despues del resumen"
 L["Add a empty line after stat summary"] = "Anade una linea vacia despues del resumen"
 -- /rb sum icon
 L["Show icon"] = "Mostrar icono"
-L["Show the sigma icon before summary listing"] = "Muestra el icono de sumatorio antes del listado resumen"
+L["Show the sigma icon before stat summary"] = "Muestra el icono de sumatorio antes del listado resumen"
 -- /rb sum title
 L["Show title text"] = "Mostrar texto titulo"
 L["Show the title text before stat summary"] = "Muestra el titulo antes del listado resumen"

--- a/locales/frFR.lua
+++ b/locales/frFR.lua
@@ -143,7 +143,7 @@ L["Add after summary"] = "Après le résumé"
 L["Add a empty line after stat summary"] = "Ajoute une ligne vide après le résumé des statistiques."
 -- /rb sum icon
 L["Show icon"] = "Ajouter l'icône"
-L["Show the sigma icon before summary listing"] = "Affiche l'icône sigma avant le résumé."
+L["Show the sigma icon before stat summary"] = "Affiche l'icône sigma avant le résumé."
 -- /rb sum title
 L["Show title text"] = "Ajouter le titre"
 L["Show the title text before stat summary"] = "Ajoute le titre avant le résumé."

--- a/locales/frFR.lua
+++ b/locales/frFR.lua
@@ -146,7 +146,9 @@ L["Show icon"] = "Ajouter l'icône"
 L["Show the sigma icon before summary listing"] = "Affiche l'icône sigma avant le résumé."
 -- /rb sum title
 L["Show title text"] = "Ajouter le titre"
-L["Show the title text before summary listing"] = "Ajoute le titre avant le résumé."
+L["Show the title text before stat summary"] = "Ajoute le titre avant le résumé."
+L["Show profile name"] = "Show profile name"
+L["Show profile name before stat summary"] = "Show profile name before stat summary"
 -- /rb sum showzerostat
 L["Show zero value stats"] = "Ajouter les stats nulles"
 L["Show zero value stats in summary for consistancy"] = "Ajoute les stats nulles/absentes de l'objet au résumé."
@@ -273,6 +275,14 @@ L["Raid Buffs"] = "Raid Buffs"
 L["Stat Multiplier"] = "Stat Multiplier"
 L["Attack Power Multiplier"] = "Attack Power Multiplier"
 L["Reduced Physical Damage Taken"] = "Reduced Physical Damage Taken"
+
+L["Swap Profiles"] = "Swap Profiles"
+L["Swap Profile Keybinding"] = "Swap Profile Keybinding"
+L["Use a keybind to swap between Primary and Secondary Profiles.\n\nIf \"Enable spec profiles\" is enabled, will use the Primary and Secondary Talents profiles, and will preview items with that spec's talents, glyphs, and passives.\n\nYou can re-use an existing keybind! It will only be used for RatingBuster when an item tooltip is shown."] = "Use a keybind to swap between Primary and Secondary Profiles.\n\nIf \"Enable spec profiles\" is enabled, will use the Primary and Secondary Talents profiles, and will preview items with that spec's talents, glyphs, and passives.\n\nYou can re-use an existing keybind! It will only be used for RatingBuster when an item tooltip is shown."
+L["Primary Profile"] = "Primary Profile"
+L["Select the primary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Primary Talents profile."] = "Select the primary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Primary Talents profile."
+L["Secondary Profile"] = "Secondary Profile"
+L["Select the secondary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Secondary Talents profile."] = "Select the secondary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Secondary Talents profile."
 
 -----------------------
 -- Matching Patterns --

--- a/locales/itIT.lua
+++ b/locales/itIT.lua
@@ -1,4 +1,4 @@
-﻿local _, addon = ...
+local _, addon = ...
 
 ---@type RatingBusterLocale
 local L = LibStub("AceLocale-3.0"):NewLocale("RatingBuster", "itIT")
@@ -118,7 +118,9 @@ L["Show icon"] = "Show icon"
 L["Show the sigma icon before summary listing"] = "Show the sigma icon before summary listing"
 -- /rb sum title
 L["Show title text"] = "Show title text"
-L["Show the title text before summary listing"] = "Show the title text before summary listing"
+L["Show the title text before stat summary"] = "Show the title text before stat summary"
+L["Show profile name"] = "Show profile name"
+L["Show profile name before stat summary"] = "Show profile name before stat summary"
 -- /rb sum showzerostat
 L["Show zero value stats"] = "Show zero value stats"
 L["Show zero value stats in summary for consistancy"] = "Show zero value stats in summary for consistancy"
@@ -248,6 +250,14 @@ L["Raid Buffs"] = "Raid Buffs"
 L["Stat Multiplier"] = "Stat Multiplier"
 L["Attack Power Multiplier"] = "Attack Power Multiplier"
 L["Reduced Physical Damage Taken"] = "Reduced Physical Damage Taken"
+
+L["Swap Profiles"] = "Swap Profiles"
+L["Swap Profile Keybinding"] = "Swap Profile Keybinding"
+L["Use a keybind to swap between Primary and Secondary Profiles.\n\nIf \"Enable spec profiles\" is enabled, will use the Primary and Secondary Talents profiles, and will preview items with that spec's talents, glyphs, and passives.\n\nYou can re-use an existing keybind! It will only be used for RatingBuster when an item tooltip is shown."] = "Use a keybind to swap between Primary and Secondary Profiles.\n\nIf \"Enable spec profiles\" is enabled, will use the Primary and Secondary Talents profiles, and will preview items with that spec's talents, glyphs, and passives.\n\nYou can re-use an existing keybind! It will only be used for RatingBuster when an item tooltip is shown."
+L["Primary Profile"] = "Primary Profile"
+L["Select the primary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Primary Talents profile."] = "Select the primary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Primary Talents profile."
+L["Secondary Profile"] = "Secondary Profile"
+L["Select the secondary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Secondary Talents profile."] = "Select the secondary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Secondary Talents profile."
 
 -----------------------
 -- Matching Patterns --

--- a/locales/itIT.lua
+++ b/locales/itIT.lua
@@ -115,7 +115,7 @@ L["Add after summary"] = "Add after summary"
 L["Add a empty line after stat summary"] = "Add a empty line after stat summary"
 -- /rb sum icon
 L["Show icon"] = "Show icon"
-L["Show the sigma icon before summary listing"] = "Show the sigma icon before summary listing"
+L["Show the sigma icon before stat summary"] = "Show the sigma icon before stat summary"
 -- /rb sum title
 L["Show title text"] = "Show title text"
 L["Show the title text before stat summary"] = "Show the title text before stat summary"

--- a/locales/koKR.lua
+++ b/locales/koKR.lua
@@ -125,7 +125,7 @@ L["Add after summary"] = "요약 뒤에 추가"
 L["Add a empty line after stat summary"] = "능력치 요약의 뒤에 구분선을 추가합니다."
 -- /rb sum icon
 L["Show icon"] = "아이콘 표시"
-L["Show the sigma icon before summary listing"] = "요약 목록 앞에 시그마 아이콘을 표시합니다."
+L["Show the sigma icon before stat summary"] = "요약 목록 앞에 시그마 아이콘을 표시합니다."
 -- /rb sum title
 L["Show title text"] = "제목 표시"
 L["Show the title text before stat summary"] = "요약 목록 앞에 제목을 표시합니다."

--- a/locales/koKR.lua
+++ b/locales/koKR.lua
@@ -1,4 +1,4 @@
-﻿--[[
+--[[
 Name: RatingBuster koKR locale
 Revision: $Revision: 73696 $
 Translated by:
@@ -128,7 +128,9 @@ L["Show icon"] = "아이콘 표시"
 L["Show the sigma icon before summary listing"] = "요약 목록 앞에 시그마 아이콘을 표시합니다."
 -- /rb sum title
 L["Show title text"] = "제목 표시"
-L["Show the title text before summary listing"] = "요약 목록 앞에 제목을 표시합니다."
+L["Show the title text before stat summary"] = "요약 목록 앞에 제목을 표시합니다."
+L["Show profile name"] = "Show profile name"
+L["Show profile name before stat summary"] = "Show profile name before stat summary"
 -- /rb sum showzerostat
 L["Show zero value stats"] = "제로 능력치 표시"
 L["Show zero value stats in summary for consistancy"] = "구성에 대한 요약에 제로 능력치를 표시합니다."
@@ -257,6 +259,14 @@ L["Raid Buffs"] = "Raid Buffs"
 L["Stat Multiplier"] = "Stat Multiplier"
 L["Attack Power Multiplier"] = "Attack Power Multiplier"
 L["Reduced Physical Damage Taken"] = "Reduced Physical Damage Taken"
+
+L["Swap Profiles"] = "Swap Profiles"
+L["Swap Profile Keybinding"] = "Swap Profile Keybinding"
+L["Use a keybind to swap between Primary and Secondary Profiles.\n\nIf \"Enable spec profiles\" is enabled, will use the Primary and Secondary Talents profiles, and will preview items with that spec's talents, glyphs, and passives.\n\nYou can re-use an existing keybind! It will only be used for RatingBuster when an item tooltip is shown."] = "Use a keybind to swap between Primary and Secondary Profiles.\n\nIf \"Enable spec profiles\" is enabled, will use the Primary and Secondary Talents profiles, and will preview items with that spec's talents, glyphs, and passives.\n\nYou can re-use an existing keybind! It will only be used for RatingBuster when an item tooltip is shown."
+L["Primary Profile"] = "Primary Profile"
+L["Select the primary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Primary Talents profile."] = "Select the primary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Primary Talents profile."
+L["Secondary Profile"] = "Secondary Profile"
+L["Select the secondary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Secondary Talents profile."] = "Select the secondary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Secondary Talents profile."
 
 -----------------------
 -- Matching Patterns --

--- a/locales/ptBR.lua
+++ b/locales/ptBR.lua
@@ -1,4 +1,4 @@
-﻿local _, addon = ...
+local _, addon = ...
 
 ---@type RatingBusterLocale
 local L = LibStub("AceLocale-3.0"):NewLocale("RatingBuster", "ptBR")
@@ -118,7 +118,9 @@ L["Show icon"] = "Show icon"
 L["Show the sigma icon before summary listing"] = "Show the sigma icon before summary listing"
 -- /rb sum title
 L["Show title text"] = "Show title text"
-L["Show the title text before summary listing"] = "Show the title text before summary listing"
+L["Show the title text before stat summary"] = "Show the title text before stat summary"
+L["Show profile name"] = "Show profile name"
+L["Show profile name before stat summary"] = "Show profile name before stat summary"
 -- /rb sum showzerostat
 L["Show zero value stats"] = "Show zero value stats"
 L["Show zero value stats in summary for consistancy"] = "Show zero value stats in summary for consistancy"
@@ -248,6 +250,14 @@ L["Raid Buffs"] = "Raid Buffs"
 L["Stat Multiplier"] = "Stat Multiplier"
 L["Attack Power Multiplier"] = "Attack Power Multiplier"
 L["Reduced Physical Damage Taken"] = "Reduced Physical Damage Taken"
+
+L["Swap Profiles"] = "Swap Profiles"
+L["Swap Profile Keybinding"] = "Swap Profile Keybinding"
+L["Use a keybind to swap between Primary and Secondary Profiles.\n\nIf \"Enable spec profiles\" is enabled, will use the Primary and Secondary Talents profiles, and will preview items with that spec's talents, glyphs, and passives.\n\nYou can re-use an existing keybind! It will only be used for RatingBuster when an item tooltip is shown."] = "Use a keybind to swap between Primary and Secondary Profiles.\n\nIf \"Enable spec profiles\" is enabled, will use the Primary and Secondary Talents profiles, and will preview items with that spec's talents, glyphs, and passives.\n\nYou can re-use an existing keybind! It will only be used for RatingBuster when an item tooltip is shown."
+L["Primary Profile"] = "Primary Profile"
+L["Select the primary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Primary Talents profile."] = "Select the primary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Primary Talents profile."
+L["Secondary Profile"] = "Secondary Profile"
+L["Select the secondary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Secondary Talents profile."] = "Select the secondary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Secondary Talents profile."
 
 -----------------------
 -- Matching Patterns --

--- a/locales/ptBR.lua
+++ b/locales/ptBR.lua
@@ -115,7 +115,7 @@ L["Add after summary"] = "Add after summary"
 L["Add a empty line after stat summary"] = "Add a empty line after stat summary"
 -- /rb sum icon
 L["Show icon"] = "Show icon"
-L["Show the sigma icon before summary listing"] = "Show the sigma icon before summary listing"
+L["Show the sigma icon before stat summary"] = "Show the sigma icon before stat summary"
 -- /rb sum title
 L["Show title text"] = "Show title text"
 L["Show the title text before stat summary"] = "Show the title text before stat summary"

--- a/locales/ruRU.lua
+++ b/locales/ruRU.lua
@@ -126,7 +126,7 @@ L["Add after summary"] = "Линия после итога"
 L["Add a empty line after stat summary"] = "Добавить линию после итога"
 -- /rb sum icon
 L["Show icon"] = "Показать иконку"
-L["Show the sigma icon before summary listing"] = "Показать знак суммы перед итогом"
+L["Show the sigma icon before stat summary"] = "Показать знак суммы перед итогом"
 -- /rb sum title
 L["Show title text"] = "Показать заголовок"
 L["Show the title text before stat summary"] = "Показать заголовок до списка итога"

--- a/locales/ruRU.lua
+++ b/locales/ruRU.lua
@@ -129,7 +129,9 @@ L["Show icon"] = "Показать иконку"
 L["Show the sigma icon before summary listing"] = "Показать знак суммы перед итогом"
 -- /rb sum title
 L["Show title text"] = "Показать заголовок"
-L["Show the title text before summary listing"] = "Показать заголовок до списка итога"
+L["Show the title text before stat summary"] = "Показать заголовок до списка итога"
+L["Show profile name"] = "Show profile name"
+L["Show profile name before stat summary"] = "Show profile name before stat summary"
 -- /rb sum showzerostat
 L["Show zero value stats"] = "Показывать нулевые статы"
 L["Show zero value stats in summary for consistancy"] = "Показывать нулевые статы"
@@ -276,6 +278,14 @@ L["Raid Buffs"] = "Raid Buffs"
 L["Stat Multiplier"] = "Stat Multiplier"
 L["Attack Power Multiplier"] = "Attack Power Multiplier"
 L["Reduced Physical Damage Taken"] = "Reduced Physical Damage Taken"
+
+L["Swap Profiles"] = "Swap Profiles"
+L["Swap Profile Keybinding"] = "Swap Profile Keybinding"
+L["Use a keybind to swap between Primary and Secondary Profiles.\n\nIf \"Enable spec profiles\" is enabled, will use the Primary and Secondary Talents profiles, and will preview items with that spec's talents, glyphs, and passives.\n\nYou can re-use an existing keybind! It will only be used for RatingBuster when an item tooltip is shown."] = "Use a keybind to swap between Primary and Secondary Profiles.\n\nIf \"Enable spec profiles\" is enabled, will use the Primary and Secondary Talents profiles, and will preview items with that spec's talents, glyphs, and passives.\n\nYou can re-use an existing keybind! It will only be used for RatingBuster when an item tooltip is shown."
+L["Primary Profile"] = "Primary Profile"
+L["Select the primary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Primary Talents profile."] = "Select the primary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Primary Talents profile."
+L["Secondary Profile"] = "Secondary Profile"
+L["Select the secondary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Secondary Talents profile."] = "Select the secondary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Secondary Talents profile."
 
 -----------------------
 -- Matching Patterns --

--- a/locales/zhCN.lua
+++ b/locales/zhCN.lua
@@ -1,4 +1,4 @@
-﻿--[[
+--[[
 Name: RatingBuster zhCN locale
 Revision: $Revision: 73696 $
 Translated by:
@@ -127,7 +127,9 @@ L["Show icon"] = "显示图示"
 L["Show the sigma icon before summary listing"] = "在属性统计前显示图示"
 -- /rb sum title
 L["Show title text"] = "显示标题"
-L["Show the title text before summary listing"] = "在属性统计前显示标题文字"
+L["Show the title text before stat summary"] = "在属性统计前显示标题文字"
+L["Show profile name"] = "Show profile name"
+L["Show profile name before stat summary"] = "Show profile name before stat summary"
 -- /rb sum showzerostat
 L["Show zero value stats"] = "显示数值为0的属性"
 L["Show zero value stats in summary for consistancy"] = "为了一致性，在统计中显示数值为0的属性"
@@ -255,6 +257,14 @@ L["Raid Buffs"] = "团队Buff"
 L["Stat Multiplier"] = "Stat Multiplier"
 L["Attack Power Multiplier"] = "Attack Power Multiplier"
 L["Reduced Physical Damage Taken"] = "Reduced Physical Damage Taken"
+
+L["Swap Profiles"] = "Swap Profiles"
+L["Swap Profile Keybinding"] = "Swap Profile Keybinding"
+L["Use a keybind to swap between Primary and Secondary Profiles.\n\nIf \"Enable spec profiles\" is enabled, will use the Primary and Secondary Talents profiles, and will preview items with that spec's talents, glyphs, and passives.\n\nYou can re-use an existing keybind! It will only be used for RatingBuster when an item tooltip is shown."] = "Use a keybind to swap between Primary and Secondary Profiles.\n\nIf \"Enable spec profiles\" is enabled, will use the Primary and Secondary Talents profiles, and will preview items with that spec's talents, glyphs, and passives.\n\nYou can re-use an existing keybind! It will only be used for RatingBuster when an item tooltip is shown."
+L["Primary Profile"] = "Primary Profile"
+L["Select the primary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Primary Talents profile."] = "Select the primary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Primary Talents profile."
+L["Secondary Profile"] = "Secondary Profile"
+L["Select the secondary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Secondary Talents profile."] = "Select the secondary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Secondary Talents profile."
 
 -----------------------
 -- Matching Patterns --

--- a/locales/zhCN.lua
+++ b/locales/zhCN.lua
@@ -124,7 +124,7 @@ L["Add after summary"] = "加在统计后"
 L["Add a empty line after stat summary"] = "在物品提示中的属性统计后加入空白列"
 -- /rb sum icon
 L["Show icon"] = "显示图示"
-L["Show the sigma icon before summary listing"] = "在属性统计前显示图示"
+L["Show the sigma icon before stat summary"] = "在属性统计前显示图示"
 -- /rb sum title
 L["Show title text"] = "显示标题"
 L["Show the title text before stat summary"] = "在属性统计前显示标题文字"

--- a/locales/zhTW.lua
+++ b/locales/zhTW.lua
@@ -1,4 +1,4 @@
-﻿--[[
+--[[
 Name: RatingBuster zhTW locale
 Revision: $Revision: 73696 $
 Translated by:
@@ -130,7 +130,9 @@ L["Show icon"] = "顯示圖示"
 L["Show the sigma icon before summary listing"] = "在屬性統計前顯示圖示"
 -- /rb sum title
 L["Show title text"] = "顯示標題"
-L["Show the title text before summary listing"] = "在屬性統計前顯示標題文字"
+L["Show the title text before stat summary"] = "在屬性統計前顯示標題文字"
+L["Show profile name"] = "Show profile name"
+L["Show profile name before stat summary"] = "Show profile name before stat summary"
 -- /rb sum showzerostat
 L["Show zero value stats"] = "顯示數值為 0 的屬性"
 L["Show zero value stats in summary for consistancy"] = "為了一致性，在統計中顯示數值為 0 的屬性"
@@ -259,6 +261,14 @@ L["Raid Buffs"] = "團隊Buff"
 L["Stat Multiplier"] = "總屬性提高%"
 L["Attack Power Multiplier"] = "攻擊強度提高%"
 L["Reduced Physical Damage Taken"] = "物理傷害減少%"
+
+L["Swap Profiles"] = "Swap Profiles"
+L["Swap Profile Keybinding"] = "Swap Profile Keybinding"
+L["Use a keybind to swap between Primary and Secondary Profiles.\n\nIf \"Enable spec profiles\" is enabled, will use the Primary and Secondary Talents profiles, and will preview items with that spec's talents, glyphs, and passives.\n\nYou can re-use an existing keybind! It will only be used for RatingBuster when an item tooltip is shown."] = "Use a keybind to swap between Primary and Secondary Profiles.\n\nIf \"Enable spec profiles\" is enabled, will use the Primary and Secondary Talents profiles, and will preview items with that spec's talents, glyphs, and passives.\n\nYou can re-use an existing keybind! It will only be used for RatingBuster when an item tooltip is shown."
+L["Primary Profile"] = "Primary Profile"
+L["Select the primary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Primary Talents profile."] = "Select the primary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Primary Talents profile."
+L["Secondary Profile"] = "Secondary Profile"
+L["Select the secondary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Secondary Talents profile."] = "Select the secondary profile for use with the swap profile keybind. If spec profiles are enabled, this will instead use the Secondary Talents profile."
 
 -----------------------
 -- Matching Patterns --

--- a/locales/zhTW.lua
+++ b/locales/zhTW.lua
@@ -127,7 +127,7 @@ L["Add after summary"] = "加在統計後"
 L["Add a empty line after stat summary"] = "在物品提示中的屬性統計後加入空白列"
 -- /rb sum icon
 L["Show icon"] = "顯示圖示"
-L["Show the sigma icon before summary listing"] = "在屬性統計前顯示圖示"
+L["Show the sigma icon before stat summary"] = "在屬性統計前顯示圖示"
 -- /rb sum title
 L["Show title text"] = "顯示標題"
 L["Show the title text before stat summary"] = "在屬性統計前顯示標題文字"


### PR DESCRIPTION
Adds menu options to set a keybinding and dropdowns to choose two profiles to toggle between.

Integrates with LibDualSpec to also preview item tooltips with your inactive spec's talents, glyphs, and passives, on top of all the other profile's chosen options like AlwaysBuffed and default gem settings.

Adds a layer to several caches so that each spec has breakdowns, sums, and StatMods cached separately, so that toggling between them is performant.

Adds an option to show the active profile name above the Stat Summary, so you can be sure which profile you're viewing stats for.
![image](https://github.com/user-attachments/assets/34919e3d-b4df-4dd0-afc9-a7b2073f67e9)

Example of toggling between a Druid's Cat and Bear profiles in Season of Discovery. The druid is out of form for both tooltips, but AlwaysBuffed is set to show Cat Form on the left (enabling AP from Agi), and the right tooltip includes Thick Hide from the inactive talent spec, as well as AlwaysBuffed settings to enable the Armor multiplier from Bear Form and the AP from Defense from Defender's Resolve.
![image](https://github.com/user-attachments/assets/3dcef3a6-3801-41c3-9e89-85901775a4ba)


